### PR TITLE
Tidy up nuget feeds

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -48,7 +48,7 @@
     <PackageVersion Include="Grpc.Net.Server" Version="$(GrpcVersion)" />    
     <PackageVersion Include="Grpc.Tools" Version="2.59.0" />
     <!-- Open Telemetry -->
-     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0-alpha.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0-alpha.1" />
     <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.7.0-alpha.1" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0-alpha.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.6.0-beta.2" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -3,42 +3,24 @@
   <packageSources>
     <clear />
     <add key="dotnet8-final" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/8.0.100-rtm.23551.15-shipping/nuget/v3/index.json" />
-    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
-    <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
     <add key="dotnet-tools-internal" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/dotnet-tools-internal/nuget/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>
   <solution>
     <add key="disableSourceControlIntegration" value="true" />
   </solution>
   <packageSourceMapping>
     <clear />
-    <packageSource key="dotnet-public">
-      <package pattern="*" />
-      <package pattern="Grpc.Tools" />
-    </packageSource>
-    <packageSource key="dotnet8">
-      <package pattern="*" />
-    </packageSource>
     <packageSource key="dotnet8-final">
       <package pattern="*" />
     </packageSource>
-    <packageSource key="nuget.org">
-      <package pattern="Duende.*" />
-      <package pattern="AspNetCore.HealthChecks.*" />
-      <package pattern="*" />
-    </packageSource>
-    <packageSource key="dotnet-libraries">
-      <package pattern="Yarp.ReverseProxy" />
-    </packageSource>
     <packageSource key="dotnet-tools-internal">
+      <package pattern="Aspire.*" />
       <package pattern="Microsoft.Extensions.ServiceDiscovery*" />
       <package pattern="Microsoft.NET.Sdk.Aspire*" />
-      <package pattern="Aspire.*" />
+    </packageSource>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
     </packageSource>
   </packageSourceMapping>
-  <disabledPackageSources>
-    <clear />
-  </disabledPackageSources>
 </configuration>


### PR DESCRIPTION
Removes unrequired feeds. Will need to remove the two remaining private feeds on launch day.