### PR TITLE
Correct typo: `envAnnoation` to `envAnnotation`

### DIFF
--- a/samples/AspireWithNode/AspireWithNode.AppHost/NodeAppAddPortLifecycleHook.cs
+++ b/samples/AspireWithNode/AspireWithNode.AppHost/NodeAppAddPortLifecycleHook.cs
@@ -1,4 +1,4 @@
-﻿using Aspire.Hosting.Lifecycle;
+using Aspire.Hosting.Lifecycle;
 
 internal class NodeAppAddPortLifecycleHook : IDistributedApplicationLifecycleHook
 {
@@ -9,7 +9,7 @@ internal class NodeAppAddPortLifecycleHook : IDistributedApplicationLifecycleHoo
         {
             if (app.TryGetServiceBindings(out var bindings))
             {
-                var envAnnoation = new EnvironmentCallbackAnnotation(env =>
+                var envAnnotation = new EnvironmentCallbackAnnotation(env =>
                 {
                     var multiBindings = bindings.Count() > 1;
 
@@ -28,7 +28,7 @@ internal class NodeAppAddPortLifecycleHook : IDistributedApplicationLifecycleHoo
                     }
                 });
 
-                app.Annotations.Add(envAnnoation);
+                app.Annotations.Add(envAnnotation);
             }
         }
 


### PR DESCRIPTION
### Description

This pull request addresses a typographical error in the codebase. The change involves correcting the spelling from `envAnnoation` to `envAnnotation` for clarity.

### Changes Made

Fixed typo in AspireWithNode\AspireWithNode.AppHost\NodeAppAddPortLifecycleHook.cs

- Before: `envAnnoation`
- After: `envAnnotation`