### PR TITLE
Set dashboards refresh rate

### DIFF
--- a/samples/Metrics/grafana/dashboards/aspnetcore-endpoint.json
+++ b/samples/Metrics/grafana/dashboards/aspnetcore-endpoint.json
@@ -775,7 +775,7 @@
       "type": "stat"
     }
   ],
-  "refresh": "",
+  "refresh": "10s",
   "revision": 1,
   "schemaVersion": 38,
   "tags": [

--- a/samples/Metrics/grafana/dashboards/aspnetcore.json
+++ b/samples/Metrics/grafana/dashboards/aspnetcore.json
@@ -1227,7 +1227,7 @@
       "type": "table"
     }
   ],
-  "refresh": "",
+  "refresh": "10s",
   "revision": 1,
   "schemaVersion": 38,
   "tags": [


### PR DESCRIPTION
Allow the metric dashboards to auto refresh.
Makes it easier to follow traffic when the auto fetch is activated in the blazor project.