### PR TITLE
eShopLite: Don't checkout if there's no user basket

### DIFF
--- a/samples/eShopLite/eShopLite.Frontend/Components/Cart.razor
+++ b/samples/eShopLite/eShopLite.Frontend/Components/Cart.razor
@@ -9,7 +9,7 @@
                 <span class="fa-stack fa-lg cart-stack pa-4">
                     <i class="fa fa-shopping-cart fa-stack-4x"></i>
                     <i class="fa fa-stack-1x badge">
-                        @itemsInCart
+                        @(customerBasket?.TotalItemCount ?? 0)
                     </i>
                 </span>
             </button>
@@ -18,28 +18,25 @@
 </div>
 
 @code {
+    CustomerBasket? customerBasket;
     bool basketIsAvailable;
-    int itemsInCart = 0;
 
     [Parameter]
     public EventCallback<bool> BasketAvailabilityChanged { get; set; }
 
     protected override async Task OnInitializedAsync()
     {
-        var (basket, isAvailable) = await BasketClient.GetBasketAsync("user");
+        (customerBasket, basketIsAvailable) = await BasketClient.GetBasketAsync("user");
 
-        if (basket is not null)
-        {
-            itemsInCart = basket.TotalItemCount;
-        }
-
-        basketIsAvailable = isAvailable;
         await BasketAvailabilityChanged.InvokeAsync(basketIsAvailable);
     }
 
     private async Task HandleCheckout()
     {
-        await BasketClient.CheckoutBasketAsync("user");
+        if (customerBasket is not null)
+        {
+            await BasketClient.CheckoutBasketAsync("user");
+        }
 
         // Preserve query string
         Navigation.NavigateTo($"/{new Uri(Navigation.Uri).Query}");


### PR DESCRIPTION
Tweak to not attempt to call the checkout basket service if the call to get the basket returned null (meaning there's no current user basket).

I'll manually port this to the version of eShopLite in the main repo too.

Fixes #36