### PR TITLE
refactor(angular): use provideHttpClient

### DIFF
--- a/samples/AspireWithJavaScript/AspireJavaScript.Angular/src/app/app.config.ts
+++ b/samples/AspireWithJavaScript/AspireJavaScript.Angular/src/app/app.config.ts
@@ -1,5 +1,5 @@
-import { ApplicationConfig, importProvidersFrom } from '@angular/core';
-import { HttpClientModule } from '@angular/common/http';
+import { ApplicationConfig } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
 import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
@@ -7,6 +7,6 @@ import { routes } from './app.routes';
 export const appConfig: ApplicationConfig = {
   providers: [
     provideRouter(routes),
-    importProvidersFrom(HttpClientModule),
+    provideHttpClient()
   ]
 };


### PR DESCRIPTION
This PR updates the JavaScript Angular example to its newest API.
The `HttpClientModule` will soon be deprecated, and later on removed.

@IEvangelist I was allowed to ping you 😉
I'll also update the docs at https://learn.microsoft.com/en-us/dotnet/aspire/get-started/build-aspire-apps-with-nodejs next 