### PR TITLE
Fix entrypoint for Vue app container

### DIFF
--- a/samples/AspireWithJavaScript/AspireJavaScript.Vue/Dockerfile
+++ b/samples/AspireWithJavaScript/AspireJavaScript.Vue/Dockerfile
@@ -11,4 +11,4 @@ COPY . .
 
 EXPOSE 5173
 
-CMD [ "npm", "dev" ]
+CMD [ "npm", "run", "dev" ]


### PR DESCRIPTION
When deploying the javascript sample with the Vue app, the container failed to start with:

```
Unknown command: "dev"
Did you mean this?
npm run dev # run the "dev" package script
```

it appears that in the container the implied script name (unlike start) is not known.