### PR TITLE
Add configuration of OTLP export endpoint to standalone dashboard sample and improve readme

### DIFF
--- a/samples/StandaloneDashboard/ConsoleApp/ConsoleApp.csproj
+++ b/samples/StandaloneDashboard/ConsoleApp/ConsoleApp.csproj
@@ -8,6 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <_WebToolingArtifacts Remove="Properties\launchSettings.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Properties\launchSettings.json" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />

--- a/samples/StandaloneDashboard/ConsoleApp/ConsoleApp.csproj
+++ b/samples/StandaloneDashboard/ConsoleApp/ConsoleApp.csproj
@@ -8,14 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <_WebToolingArtifacts Remove="Properties\launchSettings.json" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="Properties\launchSettings.json" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />

--- a/samples/StandaloneDashboard/ConsoleApp/Program.cs
+++ b/samples/StandaloneDashboard/ConsoleApp/Program.cs
@@ -40,9 +40,14 @@ static IHostApplicationBuilder ConfigureOpenTelemetry(IHostApplicationBuilder bu
             tracing.AddSource(PokemonDownloader.ActivitySourceName);
         });
 
-    builder.Services.Configure<OpenTelemetryLoggerOptions>(logging => logging.AddOtlpExporter());
-    builder.Services.ConfigureOpenTelemetryMeterProvider(metrics => metrics.AddOtlpExporter());
-    builder.Services.ConfigureOpenTelemetryTracerProvider(tracing => tracing.AddOtlpExporter());
+    // Use the OTLP exporter if the endpoint is configured.
+    var useOtlpExporter = !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
+    if (useOtlpExporter)
+    {
+        builder.Services.Configure<OpenTelemetryLoggerOptions>(logging => logging.AddOtlpExporter());
+        builder.Services.ConfigureOpenTelemetryMeterProvider(metrics => metrics.AddOtlpExporter());
+        builder.Services.ConfigureOpenTelemetryTracerProvider(tracing => tracing.AddOtlpExporter());
+    }
 
     return builder;
 }

--- a/samples/StandaloneDashboard/ConsoleApp/Properties/launchSettings.json
+++ b/samples/StandaloneDashboard/ConsoleApp/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+﻿{
+  "profiles": {
+    "ConsoleApp": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/samples/StandaloneDashboard/ConsoleApp/appsettings.Development.json
+++ b/samples/StandaloneDashboard/ConsoleApp/appsettings.Development.json
@@ -1,0 +1,7 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug"
+    }
+  }
+}

--- a/samples/StandaloneDashboard/ConsoleApp/appsettings.json
+++ b/samples/StandaloneDashboard/ConsoleApp/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information"
+    }
+  },
+  "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317"
+}

--- a/samples/StandaloneDashboard/README.md
+++ b/samples/StandaloneDashboard/README.md
@@ -12,11 +12,14 @@ description: "A sample of using the Aspire dashboard to view telemetry from non-
 
 # Standalone Aspire dashboard sample app
 
-The Aspire dashboard can be used to view OpenTelemetry data from any app. The dashboard supports running standalone, and any app can send it open telemetry.
+The Aspire dashboard can be used to view telemetry from any app. The dashboard supports running standalone, and apps configured with an [OpenTelemetry SDK](https://opentelemetry.io/docs/getting-started/dev/) send it data.
 
-This is a simple .NET app that downloads data from [PokeAPI](https://pokeapi.co/). The app sends telemetry to the Aspire dashboard which can be viewed in the dashboard telemetry UI.
+This sample is a simple .NET console app that downloads data from [PokeAPI](https://pokeapi.co/). The app sends telemetry to the Aspire dashboard which can be viewed in the dashboard telemetry UI.
 
 ![Screenshot of the standalone .NET Aspire dashboard](./images/aspire-dashboard-screenshot.png)
+
+> [!NOTE]
+> [PokeAPI](https://pokeapi.co/) is a free, open-source RESTful API that is not owned by Microsoft.
 
 ## Demonstrates
 
@@ -66,6 +69,10 @@ dotnet run --project ConsoleApp
 
 1. The console app launches, downloads information about all Pokemon and then exits.
 2. View the Aspire dashboard at http://localhost:18888 to see app telemetry.
-  1. View structured logs to see the list of downloaded Pokemon.
-  2. View traces to see HTTP requests made.
-  3. View metrics to see numeric data about the app such as average HTTP request duration.
+    1. View structured logs to see the list of downloaded Pokemon.
+    2. View traces to see HTTP requests made.
+    3. View metrics to see numeric data about the app such as average HTTP request duration.
+
+## Configure OpenTelemetry
+
+The telemetry export endpoint is configured with the `OTEL_EXPORTER_OTLP_ENDPOINT` setting. This value is set to `http://localhost:4317` in the sample's appsettings.json file. Removing the `OTEL_EXPORTER_OTLP_ENDPOINT` value disables exporting telemetry.

--- a/samples/StandaloneDashboard/README.md
+++ b/samples/StandaloneDashboard/README.md
@@ -12,9 +12,9 @@ description: "A sample of using the Aspire dashboard to view telemetry from non-
 
 # Standalone Aspire dashboard sample app
 
-The Aspire dashboard can be used to view telemetry from any app. The dashboard supports running standalone, and apps configured with an [OpenTelemetry SDK](https://opentelemetry.io/docs/getting-started/dev/) send it data.
+View telemetry from any app in the Aspire dashboard. The dashboard supports running standalone, and apps configured with an [OpenTelemetry SDK](https://opentelemetry.io/docs/getting-started/dev/) can send it data.
 
-This sample is a simple .NET console app that downloads data from [PokeAPI](https://pokeapi.co/). The app sends telemetry to the Aspire dashboard which can be viewed in the dashboard telemetry UI.
+This sample is a .NET console app that downloads data from [PokeAPI](https://pokeapi.co/). The app sends telemetry to the Aspire dashboard which is viewed in the dashboard telemetry UI.
 
 ![Screenshot of the standalone .NET Aspire dashboard](./images/aspire-dashboard-screenshot.png)
 


### PR DESCRIPTION
* Provide ability to disable OTLP export through configuration.
* Discuss configuration in the readme.
* General readme improvements.

Readme preview: https://github.com/dotnet/aspire-samples/blob/jamesnk/standalone-sample-configuration/samples/StandaloneDashboard/README.md