### PR TITLE
Fixed subscribe call in angular sample

### DIFF
--- a/samples/AspireWithJavaScript/AspireJavaScript.Angular/src/app/app.component.ts
+++ b/samples/AspireWithJavaScript/AspireJavaScript.Angular/src/app/app.component.ts
@@ -17,8 +17,8 @@ export class AppComponent {
   forecasts: WeatherForecasts = [];
 
   constructor(private http: HttpClient) {
-    http.get<WeatherForecasts>('api/weatherforecast').subscribe(result => {
-      next: this.forecasts = result;
+    http.get<WeatherForecasts>('api/weatherforecast').subscribe({
+      next: result => this.forecasts = result,
       error: console.error
     });
   }


### PR DESCRIPTION
Fixed a syntax issue where the previous code tried to pass an observer to the [`subscribe`](https://rxjs.dev/api/index/class/Observable#subscribe) method but passed an anonymous function instead. This caused the curly braces to become the body of the function and `next` and `error` to become labels.