### PR TITLE
Remove extension helpers, instead use parameters for passwords.

### DIFF
--- a/samples/VolumeMount/VolumeMount.AppHost/Program.cs
+++ b/samples/VolumeMount/VolumeMount.AppHost/Program.cs
@@ -2,17 +2,13 @@
 
 // Using a persistent volume mount requires a stable password rather than the default generated one.
 
-var sqlPassword = builder.AddParameter("sqlpassword", secret: true);
-
 // To have a persistent volume across container instances, it must be named.
-var sqlDatabase = builder.AddSqlServer("sqlserver", password: sqlPassword)
+var sqlDatabase = builder.AddSqlServer("sqlserver")
     .WithDataVolume()
     .AddDatabase("sqldb");
 
-var postgresPassword = builder.AddParameter("postgrespassword", secret: true);
-
 // Postgres must also have a stable password and a named volume
-var postgresDatabase = builder.AddPostgres("postgresserver", password: postgresPassword)
+var postgresDatabase = builder.AddPostgres("postgresserver")
     .WithDataVolume()
     .AddDatabase("postgres");
 


### PR DESCRIPTION
Remove extension helpers, instead use parameters:

- Related to https://github.com/dotnet/docs-aspire/issues/672