### PR TITLE
Increase test HttpClient retries & optionally wait for resources to transition to target state

### DIFF
--- a/tests/SamplesIntegrationTests/AppHostTests.cs
+++ b/tests/SamplesIntegrationTests/AppHostTests.cs
@@ -3,8 +3,8 @@
 
 using System.Net;
 using System.Text.Json;
-using Aspire.Hosting.Dapr;
 using Microsoft.Extensions.DependencyInjection;
+using SamplesIntegrationTests.Infrastructure;
 using Xunit.Abstractions;
 
 namespace SamplesIntegrationTests;
@@ -66,7 +66,7 @@ public class AppHostTests(ITestOutputHelper testOutput)
                     {
                         resilience.TotalRequestTimeout.Timeout = TimeSpan.FromSeconds(300);
                         resilience.AttemptTimeout.Timeout = TimeSpan.FromSeconds(60);
-                        resilience.Retry.MaxRetryAttempts = 5;
+                        resilience.Retry.MaxRetryAttempts = 30;
                         resilience.CircuitBreaker.SamplingDuration = TimeSpan.FromSeconds(300);
                     });
             });
@@ -80,15 +80,10 @@ public class AppHostTests(ITestOutputHelper testOutput)
                     continue;
                 }
 
-                try
-                {
-                    response = await client.GetAsync(path);
-                    Assert.True(HttpStatusCode.OK == response.StatusCode, $"Endpoint '{client.BaseAddress}{path.TrimStart('/')}' for resource '{resource}' in app '{Path.GetFileNameWithoutExtension(appHostPath)}' returned status code {response.StatusCode}");
-                }
-                catch (Exception ex)
-                {
-                    Assert.Fail($"Error when calling endpoint '{client.BaseAddress}{path.TrimStart('/')} for resource '{resource}' in app '{Path.GetFileNameWithoutExtension(appHostPath)}': {ex.Message}");
-                }
+                testOutput.WriteLine($"Calling endpoint '{client.BaseAddress}{path.TrimStart('/')} for resource '{resource}' in app '{Path.GetFileNameWithoutExtension(appHostPath)}'");
+                response = await client.GetAsync(path);
+
+                Assert.True(HttpStatusCode.OK == response.StatusCode, $"Endpoint '{client.BaseAddress}{path.TrimStart('/')}' for resource '{resource}' in app '{Path.GetFileNameWithoutExtension(appHostPath)}' returned status code {response.StatusCode}");
             }
         }
 

--- a/tests/SamplesIntegrationTests/Infrastructure/DistributedApplicationExtensions.cs
+++ b/tests/SamplesIntegrationTests/Infrastructure/DistributedApplicationExtensions.cs
@@ -5,12 +5,12 @@ using System.Diagnostics;
 using System.Net;
 using System.Reflection;
 using System.Security.Cryptography;
-using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using SamplesIntegrationTests.Infrastructure;
 
-namespace SamplesIntegrationTests;
+namespace SamplesIntegrationTests.Infrastructure;
 
 public static partial class DistributedApplicationExtensions
 {
@@ -40,7 +40,7 @@ public static partial class DistributedApplicationExtensions
         builder.Services.AddSingleton<ResourceLogStore>();
 
         // Configure the builder's logger to redirect it to xunit's output & store for assertion later
-        builder.Services.AddLogging(logging => logging.ClearProviders());
+        //builder.Services.AddLogging(logging => logging.ClearProviders());
         builder.Services.AddKeyedSingleton(OutputWriterKey, outputWriter);
         builder.Services.AddSingleton<LoggerLogStore>();
         builder.Services.AddSingleton<ILoggerProvider, StoredLogsLoggerProvider>();
@@ -76,7 +76,7 @@ public static partial class DistributedApplicationExtensions
     {
         // Named volumes that aren't shared across resources should be replaced with anonymous volumes.
         // Named volumes shared by mulitple resources need to have their name randomized but kept shared across those resources.
-        
+
         // Find all shared volumes and make a map of their original name to a new randomized name
         var allResourceNamedVolumes = builder.Resources.SelectMany(r => r.Annotations
             .OfType<ContainerMountAnnotation>()
@@ -143,7 +143,7 @@ public static partial class DistributedApplicationExtensions
             .ConfigureHttpClientDefaults(configure)
             .BuildServiceProvider();
         var httpClientFactory = services.GetRequiredService<IHttpClientFactory>();
-        
+
         var httpClient = httpClientFactory.CreateClient();
         httpClient.BaseAddress = app.GetEndpoint(resourceName, endpointName);
 

--- a/tests/SamplesIntegrationTests/Infrastructure/DistributedApplicationExtensions.cs
+++ b/tests/SamplesIntegrationTests/Infrastructure/DistributedApplicationExtensions.cs
@@ -160,6 +160,12 @@ public static partial class DistributedApplicationExtensions
         await resourcesStartingTask;
     }
 
+    public static async Task WaitForResource(this DistributedApplication app, string resourceName, string state = "Running", CancellationToken cancellationToken = default)
+    {
+        var resourceWatcher = app.Services.GetRequiredService<ResourceWatcher>();
+        await resourceWatcher.WaitForResource(resourceName, state, cancellationToken);
+    }
+
     public static LoggerLogStore GetAppHostLogs(this DistributedApplication app)
     {
         var logStore = app.Services.GetService<LoggerLogStore>()

--- a/tests/SamplesIntegrationTests/Infrastructure/DistributedApplicationExtensions.cs
+++ b/tests/SamplesIntegrationTests/Infrastructure/DistributedApplicationExtensions.cs
@@ -40,7 +40,6 @@ public static partial class DistributedApplicationExtensions
         builder.Services.AddSingleton<ResourceLogStore>();
 
         // Configure the builder's logger to redirect it to xunit's output & store for assertion later
-        //builder.Services.AddLogging(logging => logging.ClearProviders());
         builder.Services.AddKeyedSingleton(OutputWriterKey, outputWriter);
         builder.Services.AddSingleton<LoggerLogStore>();
         builder.Services.AddSingleton<ILoggerProvider, StoredLogsLoggerProvider>();

--- a/tests/SamplesIntegrationTests/Infrastructure/DistributedApplicationExtensions.cs
+++ b/tests/SamplesIntegrationTests/Infrastructure/DistributedApplicationExtensions.cs
@@ -159,10 +159,10 @@ public static partial class DistributedApplicationExtensions
         await resourcesStartingTask;
     }
 
-    public static async Task WaitForResource(this DistributedApplication app, string resourceName, string state = "Running", CancellationToken cancellationToken = default)
+    public static Task WaitForResource(this DistributedApplication app, string resourceName, string targetState = "Running", CancellationToken cancellationToken = default)
     {
         var resourceWatcher = app.Services.GetRequiredService<ResourceWatcher>();
-        await resourceWatcher.WaitForResource(resourceName, state, cancellationToken);
+        return resourceWatcher.WaitForResource(resourceName, targetState, cancellationToken);
     }
 
     public static LoggerLogStore GetAppHostLogs(this DistributedApplication app)

--- a/tests/SamplesIntegrationTests/Infrastructure/DistributedApplicationTestFactory.cs
+++ b/tests/SamplesIntegrationTests/Infrastructure/DistributedApplicationTestFactory.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Reflection;
+using SamplesIntegrationTests.Infrastructure;
 
 namespace SamplesIntegrationTests;
 

--- a/tests/SamplesIntegrationTests/Infrastructure/LoggerLogStore.cs
+++ b/tests/SamplesIntegrationTests/Infrastructure/LoggerLogStore.cs
@@ -2,7 +2,7 @@
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
-namespace SamplesIntegrationTests;
+namespace SamplesIntegrationTests.Infrastructure;
 
 /// <summary>
 /// Stores logs from <see cref="ILogger"/> instances created from <see cref="StoredLogsLoggerProvider"/>.

--- a/tests/SamplesIntegrationTests/Infrastructure/PasswordGenerator.cs
+++ b/tests/SamplesIntegrationTests/Infrastructure/PasswordGenerator.cs
@@ -5,7 +5,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 
-namespace Aspire.Hosting.Utils;
+namespace SamplesIntegrationTests.Infrastructure;
 
 internal static class PasswordGenerator
 {

--- a/tests/SamplesIntegrationTests/Infrastructure/ResourceExtensions.cs
+++ b/tests/SamplesIntegrationTests/Infrastructure/ResourceExtensions.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace SamplesIntegrationTests;
+namespace SamplesIntegrationTests.Infrastructure;
 
 internal static class ResourceExtensions
 {

--- a/tests/SamplesIntegrationTests/Infrastructure/ResourceLogStore.cs
+++ b/tests/SamplesIntegrationTests/Infrastructure/ResourceLogStore.cs
@@ -3,7 +3,7 @@
 
 using System.Collections.Concurrent;
 
-namespace SamplesIntegrationTests;
+namespace SamplesIntegrationTests.Infrastructure;
 
 public class ResourceLogStore
 {

--- a/tests/SamplesIntegrationTests/Infrastructure/ResourceWatcher.cs
+++ b/tests/SamplesIntegrationTests/Infrastructure/ResourceWatcher.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
-using Aspire.Hosting.ApplicationModel;
-using Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;

--- a/tests/SamplesIntegrationTests/Infrastructure/ResourceWatcher.cs
+++ b/tests/SamplesIntegrationTests/Infrastructure/ResourceWatcher.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
-namespace SamplesIntegrationTests;
+namespace SamplesIntegrationTests.Infrastructure;
 
 /// <summary>
 /// A background service that watches for resource start/stop notifications and logs resource state changes.

--- a/tests/SamplesIntegrationTests/Infrastructure/StoredLogsLogger.cs
+++ b/tests/SamplesIntegrationTests/Infrastructure/StoredLogsLogger.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Extensions.Logging;
 
-namespace SamplesIntegrationTests;
+namespace SamplesIntegrationTests.Infrastructure;
 
 /// <summary>
 /// A logger that stores logs in a <see cref="LoggerLogStore"/>.

--- a/tests/SamplesIntegrationTests/Infrastructure/StoredLogsLoggerProvider.cs
+++ b/tests/SamplesIntegrationTests/Infrastructure/StoredLogsLoggerProvider.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Extensions.Logging;
 
-namespace SamplesIntegrationTests;
+namespace SamplesIntegrationTests.Infrastructure;
 
 /// <summary>
 /// A logger provider that stores logs in an <see cref="LoggerLogStore"/>.

--- a/tests/SamplesIntegrationTests/Infrastructure/XUnitExtensions.cs
+++ b/tests/SamplesIntegrationTests/Infrastructure/XUnitExtensions.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using SamplesIntegrationTests.Infrastructure;
 using Xunit.Abstractions;
 
 namespace SamplesIntegrationTests;
@@ -14,7 +15,7 @@ internal static partial class DistributedApplicationTestFactory
     /// </summary>
     public static async Task<IDistributedApplicationTestingBuilder> CreateAsync(string appHostAssemblyPath, ITestOutputHelper testOutputHelper)
     {
-        var builder = await CreateAsync(appHostAssemblyPath, new XunitTextWriter(testOutputHelper));
+        var builder = await CreateAsync(appHostAssemblyPath, new XUnitTextWriter(testOutputHelper));
         builder.Services.AddSingleton<ILoggerProvider, XUnitLoggerProvider>();
         builder.Services.AddSingleton(testOutputHelper);
         return builder;

--- a/tests/SamplesIntegrationTests/Infrastructure/XUnitLogger.cs
+++ b/tests/SamplesIntegrationTests/Infrastructure/XUnitLogger.cs
@@ -5,7 +5,7 @@ using System.Text;
 using Microsoft.Extensions.Logging;
 using Xunit.Abstractions;
 
-namespace SamplesIntegrationTests;
+namespace SamplesIntegrationTests.Infrastructure;
 
 /// <summary>
 /// An <see cref="ILogger"/> that writes log messages to an <see cref="ITestOutputHelper"/>.

--- a/tests/SamplesIntegrationTests/Infrastructure/XUnitLoggerProvider.cs
+++ b/tests/SamplesIntegrationTests/Infrastructure/XUnitLoggerProvider.cs
@@ -4,7 +4,7 @@
 using Microsoft.Extensions.Logging;
 using Xunit.Abstractions;
 
-namespace SamplesIntegrationTests;
+namespace SamplesIntegrationTests.Infrastructure;
 
 /// <summary>
 /// An <see cref="ILoggerProvider"/> that creates <see cref="ILogger"/> instances that output to the supplied <see cref="ITestOutputHelper"/>.

--- a/tests/SamplesIntegrationTests/Infrastructure/XUnitTextWriter.cs
+++ b/tests/SamplesIntegrationTests/Infrastructure/XUnitTextWriter.cs
@@ -4,12 +4,12 @@
 using System.Text;
 using Xunit.Abstractions;
 
-namespace SamplesIntegrationTests;
+namespace SamplesIntegrationTests.Infrastructure;
 
 /// <summary>
 /// A <see cref="TextWriter"/> that writes to an <see cref="ITestOutputHelper"/>.
 /// </summary>
-internal class XunitTextWriter(ITestOutputHelper output) : TextWriter
+internal class XUnitTextWriter(ITestOutputHelper output) : TextWriter
 {
     private readonly StringBuilder _sb = new();
 

--- a/tests/SamplesIntegrationTests/SamplesIntegrationTests.csproj
+++ b/tests/SamplesIntegrationTests/SamplesIntegrationTests.csproj
@@ -30,8 +30,7 @@
     <ThisProject Include="$(MSBuildThisFileFullPath)" />
   </ItemGroup>
 
-  <Target Name="CommandLineRestoreMyself" BeforeTargets="CollectPackageReferences" Condition=" '$(RestoreMyself)' == 'True' "
-          Inputs="@(ThisProject)" Outputs="$(ProjectAssetsFile)">
+  <Target Name="CommandLineRestoreMyself" BeforeTargets="CollectPackageReferences" Condition=" '$(RestoreMyself)' == 'True' " Inputs="@(ThisProject)" Outputs="$(ProjectAssetsFile)">
     <Message Importance="High" Text="Forcing a command-line restore of $(MSBuildThisFile)" />
     <MSBuild Targets="Restore" Projects="@(ThisProject)" Properties="RestoreMyself='false'" />
   </Target>


### PR DESCRIPTION
Would appreciate your eyes @davidfowl @radical @ReubenBond 

The DatabaseMigrations sample test was flakey as the migrations project is just a console app so has no healthcheck endpoint that can be monitored before trying to call the actual app endpoint, so it would sometimes fail because the retries for the app endpoint would get exhausted before the migration had finished. Now, the test can wait for a specific resource to enter a specific state before continuing, which I use to wait for the migration app to exit before hitting the actual app endpoints.  