### PR TITLE
Update for 8.0 GA (stable versions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
       DOTNET_NOLOGO: true
       DOTNET_MULTILEVEL_LOOKUP: false
+      DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE: true
       DOTNET_INSTALL_DIR: ${{ matrix.os == 'ubuntu-latest' && '' || 'dotnet' }}
       ASPIRE_ALLOW_UNSECURED_TRANSPORT: true
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
       DOTNET_NOLOGO: true
       DOTNET_MULTILEVEL_LOOKUP: false
-      DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE: true
       DOTNET_INSTALL_DIR: ${{ matrix.os == 'ubuntu-latest' && '' || 'dotnet' }}
       ASPIRE_ALLOW_UNSECURED_TRANSPORT: true
     steps:

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,7 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="aspire-stable" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspire-7d0dde41/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>
   <solution>
@@ -10,11 +9,6 @@
   </solution>
   <packageSourceMapping>
     <clear />
-    <packageSource key="aspire-stable">
-      <package pattern="Aspire.*" />
-      <package pattern="Microsoft.Extensions.ServiceDiscovery.*" />
-      <package pattern="Microsoft.Extensions.ServiceDiscovery" />
-    </packageSource>
     <packageSource key="nuget.org">
       <package pattern="*" />
     </packageSource>

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,9 +2,21 @@
 <configuration>
   <packageSources>
     <clear />
+    <add key="aspire-stable" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspire-7d0dde41/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>
   <solution>
     <add key="disableSourceControlIntegration" value="true" />
   </solution>
+  <packageSourceMapping>
+    <clear />
+    <packageSource key="aspire-stable">
+      <package pattern="Aspire.*" />
+      <package pattern="Microsoft.Extensions.ServiceDiscovery.*" />
+      <package pattern="Microsoft.Extensions.ServiceDiscovery" />
+    </packageSource>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>

--- a/samples/AspireShop/AspireShop.AppHost/AspireShop.AppHost.csproj
+++ b/samples/AspireShop/AspireShop.AppHost/AspireShop.AppHost.csproj
@@ -14,9 +14,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.0-preview.7.24251.11" />
-    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="8.0.0-preview.7.24251.11" />
-    <PackageReference Include="Aspire.Hosting.Redis" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.0" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="8.0.0" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="8.0.0" />
     <ProjectReference Include="..\AspireShop.BasketService\AspireShop.BasketService.csproj" />
     <ProjectReference Include="..\AspireShop.CatalogDbManager\AspireShop.CatalogDbManager.csproj" />
     <ProjectReference Include="..\AspireShop.CatalogService\AspireShop.CatalogService.csproj" />

--- a/samples/AspireShop/AspireShop.BasketService/AspireShop.BasketService.csproj
+++ b/samples/AspireShop/AspireShop.BasketService/AspireShop.BasketService.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore" Version="2.62.0" />
     <PackageReference Include="Grpc.AspNetCore.HealthChecks" Version="2.62.0" />
-    <PackageReference Include="Aspire.StackExchange.Redis" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Aspire.StackExchange.Redis" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/AspireShop/AspireShop.CatalogDb/AspireShop.CatalogDb.csproj
+++ b/samples/AspireShop/AspireShop.CatalogDb/AspireShop.CatalogDb.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/AspireShop/AspireShop.CatalogDbManager/AspireShop.CatalogDbManager.csproj
+++ b/samples/AspireShop/AspireShop.CatalogDbManager/AspireShop.CatalogDbManager.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/samples/AspireShop/AspireShop.CatalogService/AspireShop.CatalogService.csproj
+++ b/samples/AspireShop/AspireShop.CatalogService/AspireShop.CatalogService.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/AspireShop/AspireShop.Frontend/AspireShop.Frontend.csproj
+++ b/samples/AspireShop/AspireShop.Frontend/AspireShop.Frontend.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="8.0.0" />
     <PackageReference Include="Yarp.ReverseProxy" Version="2.1.0" />
     <PackageReference Include="Grpc.Net.ClientFactory" Version="2.62.0" />
     <PackageReference Include="Grpc.Tools" Version="2.63.0">

--- a/samples/AspireShop/AspireShop.ServiceDefaults/AspireShop.ServiceDefaults.csproj
+++ b/samples/AspireShop/AspireShop.ServiceDefaults/AspireShop.ServiceDefaults.csproj
@@ -12,7 +12,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.4.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />

--- a/samples/AspireWithDapr/AspireWithDapr.AppHost/AspireWithDapr.AppHost.csproj
+++ b/samples/AspireWithDapr/AspireWithDapr.AppHost/AspireWithDapr.AppHost.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.0-preview.7.24251.11" />
-    <PackageReference Include="Aspire.Hosting.Dapr" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.0" />
+    <PackageReference Include="Aspire.Hosting.Dapr" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/AspireWithDapr/AspireWithDapr.ServiceDefaults/AspireWithDapr.ServiceDefaults.csproj
+++ b/samples/AspireWithDapr/AspireWithDapr.ServiceDefaults/AspireWithDapr.ServiceDefaults.csproj
@@ -12,7 +12,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.4.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />

--- a/samples/AspireWithJavaScript/AspireJavaScript.AppHost/AspireJavaScript.AppHost.csproj
+++ b/samples/AspireWithJavaScript/AspireJavaScript.AppHost/AspireJavaScript.AppHost.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.0-preview.7.24251.11" />
-    <PackageReference Include="Aspire.Hosting.NodeJs" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.0" />
+    <PackageReference Include="Aspire.Hosting.NodeJs" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/AspireWithJavaScript/AspireJavaScript.ServiceDefaults/AspireJavaScript.ServiceDefaults.csproj
+++ b/samples/AspireWithJavaScript/AspireJavaScript.ServiceDefaults/AspireJavaScript.ServiceDefaults.csproj
@@ -12,7 +12,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.4.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />

--- a/samples/AspireWithNode/AspireWithNode.AppHost/AspireWithNode.AppHost.csproj
+++ b/samples/AspireWithNode/AspireWithNode.AppHost/AspireWithNode.AppHost.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.0-preview.7.24251.11" />
-    <PackageReference Include="Aspire.Hosting.NodeJs" Version="8.0.0-preview.7.24251.11" />
-    <PackageReference Include="Aspire.Hosting.Redis" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.0" />
+    <PackageReference Include="Aspire.Hosting.NodeJs" Version="8.0.0" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/AspireWithNode/AspireWithNode.ServiceDefaults/AspireWithNode.ServiceDefaults.csproj
+++ b/samples/AspireWithNode/AspireWithNode.ServiceDefaults/AspireWithNode.ServiceDefaults.csproj
@@ -12,7 +12,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.4.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />

--- a/samples/ClientAppsIntegration/ClientAppsIntegration.AppDefaults/ClientAppsIntegration.AppDefaults.csproj
+++ b/samples/ClientAppsIntegration/ClientAppsIntegration.AppDefaults/ClientAppsIntegration.AppDefaults.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.4.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />

--- a/samples/ClientAppsIntegration/ClientAppsIntegration.AppHost/ClientAppsIntegration.AppHost.csproj
+++ b/samples/ClientAppsIntegration/ClientAppsIntegration.AppHost/ClientAppsIntegration.AppHost.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/ClientAppsIntegration/ClientAppsIntegration.ServiceDefaults/ClientAppsIntegration.ServiceDefaults.csproj
+++ b/samples/ClientAppsIntegration/ClientAppsIntegration.ServiceDefaults/ClientAppsIntegration.ServiceDefaults.csproj
@@ -12,7 +12,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.4.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />

--- a/samples/DatabaseContainers/DatabaseContainers.ApiService/DatabaseContainers.ApiService.csproj
+++ b/samples/DatabaseContainers/DatabaseContainers.ApiService/DatabaseContainers.ApiService.csproj
@@ -12,9 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Microsoft.Data.SqlClient" Version="8.0.0-preview.7.24251.11" />
-    <PackageReference Include="Aspire.Npgsql" Version="8.0.0-preview.7.24251.11" />
-    <PackageReference Include="Aspire.MySqlConnector" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Aspire.Microsoft.Data.SqlClient" Version="8.0.0" />
+    <PackageReference Include="Aspire.Npgsql" Version="8.0.0" />
+    <PackageReference Include="Aspire.MySqlConnector" Version="8.0.0" />
     <PackageReference Include="Dapper" Version="2.1.35" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>

--- a/samples/DatabaseContainers/DatabaseContainers.AppHost/DatabaseContainers.AppHost.csproj
+++ b/samples/DatabaseContainers/DatabaseContainers.AppHost/DatabaseContainers.AppHost.csproj
@@ -13,10 +13,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.0-preview.7.24251.11" />
-    <PackageReference Include="Aspire.Hosting.MySql" Version="8.0.0-preview.7.24251.11" />
-    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="8.0.0-preview.7.24251.11" />
-    <PackageReference Include="Aspire.Hosting.SqlServer" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.0" />
+    <PackageReference Include="Aspire.Hosting.MySql" Version="8.0.0" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="8.0.0" />
+    <PackageReference Include="Aspire.Hosting.SqlServer" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/DatabaseContainers/DatabaseContainers.ServiceDefaults/DatabaseContainers.ServiceDefaults.csproj
+++ b/samples/DatabaseContainers/DatabaseContainers.ServiceDefaults/DatabaseContainers.ServiceDefaults.csproj
@@ -12,7 +12,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.4.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />

--- a/samples/DatabaseMigrations/DatabaseMigrations.ApiService/DatabaseMigrations.ApiService.csproj
+++ b/samples/DatabaseMigrations/DatabaseMigrations.ApiService/DatabaseMigrations.ApiService.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
 
     <ProjectReference Include="..\DatabaseMigrations.ApiModel\DatabaseMigrations.ApiModel.csproj" />
     <ProjectReference Include="..\DatabaseMigrations.ServiceDefaults\DatabaseMigrations.ServiceDefaults.csproj" />

--- a/samples/DatabaseMigrations/DatabaseMigrations.AppHost/DatabaseMigrations.AppHost.csproj
+++ b/samples/DatabaseMigrations/DatabaseMigrations.AppHost/DatabaseMigrations.AppHost.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.0-preview.7.24251.11" />
-    <PackageReference Include="Aspire.Hosting.SqlServer" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.0" />
+    <PackageReference Include="Aspire.Hosting.SqlServer" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/DatabaseMigrations/DatabaseMigrations.MigrationService/DatabaseMigrations.MigrationService.csproj
+++ b/samples/DatabaseMigrations/DatabaseMigrations.MigrationService/DatabaseMigrations.MigrationService.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
     
     <ProjectReference Include="..\DatabaseMigrations.ApiModel\DatabaseMigrations.ApiModel.csproj" />
     <ProjectReference Include="..\DatabaseMigrations.ServiceDefaults\DatabaseMigrations.ServiceDefaults.csproj" />

--- a/samples/DatabaseMigrations/DatabaseMigrations.ServiceDefaults/DatabaseMigrations.ServiceDefaults.csproj
+++ b/samples/DatabaseMigrations/DatabaseMigrations.ServiceDefaults/DatabaseMigrations.ServiceDefaults.csproj
@@ -12,7 +12,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.4.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />

--- a/samples/Metrics/MetricsApp.AppHost/MetricsApp.AppHost.csproj
+++ b/samples/Metrics/MetricsApp.AppHost/MetricsApp.AppHost.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.0" />
 
     <ProjectReference Include="..\MetricsApp\MetricsApp.csproj" />
   </ItemGroup>

--- a/samples/Metrics/ServiceDefaults/ServiceDefaults.csproj
+++ b/samples/Metrics/ServiceDefaults/ServiceDefaults.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.4" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.4.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
     <!-- BUG: 1.8.0-rc.1 breaks prometheus exporter so sticking to 1.8.0-beta.1 for now https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1617 -->
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.8.0-rc.1" />

--- a/samples/OrleansVoting/OrleansVoting.AppHost/OrleansVoting.AppHost.csproj
+++ b/samples/OrleansVoting/OrleansVoting.AppHost/OrleansVoting.AppHost.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.0-preview.7.24251.11" />
-    <PackageReference Include="Aspire.Hosting.Redis" Version="8.0.0-preview.7.24251.11" />
-    <PackageReference Include="Aspire.Hosting.Orleans" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.0" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="8.0.0" />
+    <PackageReference Include="Aspire.Hosting.Orleans" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/OrleansVoting/OrleansVoting.Service/OrleansVoting.Service.csproj
+++ b/samples/OrleansVoting/OrleansVoting.Service/OrleansVoting.Service.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.StackExchange.Redis" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Aspire.StackExchange.Redis" Version="8.0.0" />
     <PackageReference Include="Microsoft.Orleans.Clustering.Redis" Version="8.1.0" />
     <PackageReference Include="Microsoft.Orleans.Persistence.Redis" Version="8.1.0"/>
     <PackageReference Include="Microsoft.Orleans.Server" Version="8.1.0"/>

--- a/samples/OrleansVoting/OrleansVoting.ServiceDefaults/OrleansVoting.ServiceDefaults.csproj
+++ b/samples/OrleansVoting/OrleansVoting.ServiceDefaults/OrleansVoting.ServiceDefaults.csproj
@@ -12,7 +12,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.4.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />

--- a/samples/VolumeMount/VolumeMount.AppHost/VolumeMount.AppHost.csproj
+++ b/samples/VolumeMount/VolumeMount.AppHost/VolumeMount.AppHost.csproj
@@ -14,11 +14,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.0-preview.7.24251.11" />
-    <PackageReference Include="Aspire.Hosting.Azure" Version="8.0.0-preview.7.24251.11" />
-    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="8.0.0-preview.7.24251.11" />
-    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="8.0.0-preview.7.24251.11" />
-    <PackageReference Include="Aspire.Hosting.SqlServer" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.0" />
+    <PackageReference Include="Aspire.Hosting.Azure" Version="8.0.0" />
+    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="8.0.0" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="8.0.0" />
+    <PackageReference Include="Aspire.Hosting.SqlServer" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/VolumeMount/VolumeMount.BlazorWeb/VolumeMount.BlazorWeb.csproj
+++ b/samples/VolumeMount/VolumeMount.BlazorWeb/VolumeMount.BlazorWeb.csproj
@@ -12,9 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Azure.Storage.Blobs" Version="8.0.0-preview.7.24251.11" />
-    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0-preview.7.24251.11" />
-    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Aspire.Azure.Storage.Blobs" Version="8.0.0" />
+    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.4" />

--- a/samples/VolumeMount/VolumeMount.ServiceDefaults/VolumeMount.ServiceDefaults.csproj
+++ b/samples/VolumeMount/VolumeMount.ServiceDefaults/VolumeMount.ServiceDefaults.csproj
@@ -12,7 +12,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.4.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />

--- a/tests/SamplesIntegrationTests/SamplesIntegrationTests.csproj
+++ b/tests/SamplesIntegrationTests/SamplesIntegrationTests.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.0-preview.7.24251.11" />
-    <PackageReference Include="Aspire.Hosting.Azure" Version="8.0.0-preview.7.24251.11" />
-    <PackageReference Include="Aspire.Hosting.Testing" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.0" />
+    <PackageReference Include="Aspire.Hosting.Azure" Version="8.0.0" />
+    <PackageReference Include="Aspire.Hosting.Testing" Version="8.0.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0-release-24177-07" />
     <PackageReference Include="xunit" Version="2.8.0" />


### PR DESCRIPTION
Updating samples for 8.0 GA release using stable versions.

This will need the nuget.config and CI changes reverted before merging.