### PR TITLE
Move migrations to DatabaseMigrations.MigrationService

### DIFF
--- a/samples/DatabaseMigrations/DatabaseMigrations.ApiModel/DatabaseMigrations.ApiModel.csproj
+++ b/samples/DatabaseMigrations/DatabaseMigrations.ApiModel/DatabaseMigrations.ApiModel.csproj
@@ -9,10 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.6">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
   </ItemGroup>
 

--- a/samples/DatabaseMigrations/DatabaseMigrations.ApiModel/MyDb1Context.cs
+++ b/samples/DatabaseMigrations/DatabaseMigrations.ApiModel/MyDb1Context.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore;

--- a/samples/DatabaseMigrations/DatabaseMigrations.ApiService/Program.cs
+++ b/samples/DatabaseMigrations/DatabaseMigrations.ApiService/Program.cs
@@ -10,8 +10,7 @@ builder.AddServiceDefaults();
 builder.Services.AddDbContextPool<MyDb1Context>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("db1"), sqlOptions =>
     {
-        sqlOptions.MigrationsAssembly("DatabaseMigrations.ApiModel");
-        // Workround for https://github.com/dotnet/aspire/issues/1023
+        // Workaround for https://github.com/dotnet/aspire/issues/1023
         sqlOptions.ExecutionStrategy(c => new RetryingSqlServerRetryingExecutionStrategy(c));
     }));
 builder.EnrichSqlServerDbContext<MyDb1Context>(settings =>

--- a/samples/DatabaseMigrations/DatabaseMigrations.MigrationService/DatabaseMigrations.MigrationService.csproj
+++ b/samples/DatabaseMigrations/DatabaseMigrations.MigrationService/DatabaseMigrations.MigrationService.csproj
@@ -17,11 +17,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.1" />
-    
     <ProjectReference Include="..\DatabaseMigrations.ApiModel\DatabaseMigrations.ApiModel.csproj" />
     <ProjectReference Include="..\DatabaseMigrations.ServiceDefaults\DatabaseMigrations.ServiceDefaults.csproj" />
   </ItemGroup>

--- a/samples/DatabaseMigrations/DatabaseMigrations.MigrationService/Migrations/20240216140519_InitialCreate.Designer.cs
+++ b/samples/DatabaseMigrations/DatabaseMigrations.MigrationService/Migrations/20240216140519_InitialCreate.Designer.cs
@@ -3,16 +3,19 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace DatabaseMigrations.ApiModel.Migrations
+namespace DatabaseMigrations.MigrationService.Migrations
 {
     [DbContext(typeof(MyDb1Context))]
-    partial class MyDb1ContextModelSnapshot : ModelSnapshot
+    [Migration("20240216140519_InitialCreate")]
+    partial class InitialCreate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/samples/DatabaseMigrations/DatabaseMigrations.MigrationService/Migrations/20240216140519_InitialCreate.cs
+++ b/samples/DatabaseMigrations/DatabaseMigrations.MigrationService/Migrations/20240216140519_InitialCreate.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
-namespace DatabaseMigrations.ApiModel.Migrations
+namespace DatabaseMigrations.MigrationService.Migrations
 {
     /// <inheritdoc />
     public partial class InitialCreate : Migration

--- a/samples/DatabaseMigrations/DatabaseMigrations.MigrationService/Migrations/MyDb1ContextModelSnapshot.cs
+++ b/samples/DatabaseMigrations/DatabaseMigrations.MigrationService/Migrations/MyDb1ContextModelSnapshot.cs
@@ -3,19 +3,16 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace DatabaseMigrations.ApiModel.Migrations
+namespace DatabaseMigrations.MigrationService.Migrations
 {
     [DbContext(typeof(MyDb1Context))]
-    [Migration("20240216140519_InitialCreate")]
-    partial class InitialCreate
+    partial class MyDb1ContextModelSnapshot : ModelSnapshot
     {
-        /// <inheritdoc />
-        protected override void BuildTargetModel(ModelBuilder modelBuilder)
+        protected override void BuildModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -32,7 +29,7 @@ namespace DatabaseMigrations.ApiModel.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("Entries");
+                    b.ToTable("Entries", (string)null);
                 });
 #pragma warning restore 612, 618
         }

--- a/samples/DatabaseMigrations/DatabaseMigrations.MigrationService/Program.cs
+++ b/samples/DatabaseMigrations/DatabaseMigrations.MigrationService/Program.cs
@@ -15,7 +15,8 @@ builder.Services.AddOpenTelemetry()
 builder.Services.AddDbContextPool<MyDb1Context>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("db1"), sqlOptions =>
     {
-        // Workround for https://github.com/dotnet/aspire/issues/1023
+        sqlOptions.MigrationsAssembly("DatabaseMigrations.MigrationService");
+        // Workaround for https://github.com/dotnet/aspire/issues/1023
         sqlOptions.ExecutionStrategy(c => new RetryingSqlServerRetryingExecutionStrategy(c));
     }));
 builder.EnrichSqlServerDbContext<MyDb1Context>(settings =>

--- a/samples/DatabaseMigrations/README.md
+++ b/samples/DatabaseMigrations/README.md
@@ -16,9 +16,9 @@ This sample demonstrates how to use Entity Framework Core's [migrations feature]
 
 The sample has three important projects:
 
-- `DatabaseMigrations.ApiService` - A web app that calls the database.
+- `DatabaseMigrations.ApiService` - A web app that uses the database.
 - `DatabaseMigrations.MigrationService` - A background worker app that applies migrations when it starts up.
-- `DatabaseMigrations.ApiModel` - The EF Core context, entities, and migrations. This project is used by the API and migration service.
+- `DatabaseMigrations.ApiModel` - The EF Core context and entity types. This project is used by both the API and migration service.
 
 `DatabaseMigrations.ApiService` and `DatabaseMigrations.MigrationService` reference a SQL Server resource. During local development the SQL Server resource is launched in a container.
 
@@ -33,7 +33,7 @@ This sample is written in C# and targets .NET 8.0. It requires the [.NET 8.0 SDK
 
 ## Create migration
 
-The `DatabaseMigrations.ApiModel` project contains the EF Core model and migrations. The [`dotnet ef` command-line tool](https://learn.microsoft.com/ef/core/managing-schemas/migrations/#install-the-tools) can be used to create new migrations:
+The `DatabaseMigrations.MigrationService` project contains the EF Core migrations. The [`dotnet ef` command-line tool](https://learn.microsoft.com/ef/core/managing-schemas/migrations/#install-the-tools) can be used to create new migrations:
 
 1. Update the `Entry` entity in database context in `MyDb1Context.cs`. Add a `Name` property:
 
@@ -45,19 +45,22 @@ The `DatabaseMigrations.ApiModel` project contains the EF Core model and migrati
     }
     ```
 
-2. Open a command prompt in the `DatabaseMigrations.ApiService` directory and run the EF Core migration tool to create a migration named **MyNewMigration**.
+2. Open a command prompt in the `DatabaseMigrations.MigrationService` directory and run the EF Core migration tool to create a migration named **MyNewMigration**.
 
     ```bash
-    dotnet ef migrations add MyNewMigration --project ..\DatabaseMigrations.ApiModel\DatabaseMigrations.ApiModel.csproj
+    dotnet ef migrations add MyNewMigration
     ```
 
     The preceding command:
 
-      * Runs EF Core migration command-line tool in the `DatabaseMigrations.ApiService` directory. `dotnet ef` is run in this location because the API service is where the DB context is used.
-      * Creates a migration named `MyNewMigration`.
-      * Creates the migration in the `DatabaseMigrations.ApiModel` project.
+      - Runs EF Core migration command-line tool in the `DatabaseMigrations.MigrationService` directory.
+        - `dotnet ef` is run in this location because it will be used as the default target project for the new migration and the tool will run the startup code in `Program.cs` to find and configure the context to be used.
+      - Creates the migration named `MyNewMigration` in the `DatabaseMigrations.MigrationService` project.
 
-4. View the new migration files in the `DatabaseMigrations.ApiModel` project.
+3. View the new migration files in the `DatabaseMigrations.ApiModel` project.
+
+> [!NOTE]
+> To remove the unapplied migration you need to run `dotnet ef migrations remove --force`.  The `--force` switch tells the tool to avoid connecting to the database
 
 ## Run the app
 
@@ -67,6 +70,6 @@ If using the .NET CLI, run `dotnet run` from the `DatabaseContainers.AppHost` di
 
 When the app starts up, the `DatabaseMigrations.MigrationService` background worker runs migrations on the SQL Server container. The migration service:
 
-* Creates a database in the SQL Server container.
-* Creates the database schema.
-* Stops itself once the migration is complete.
+- Creates a database in the SQL Server container.
+- Creates the database schema.
+- Stops itself once the migration is complete.


### PR DESCRIPTION
This makes the `ApiService` compatible with NativeAOT and simplifies the tooling commands