### PR TITLE
Get more linter clean

### DIFF
--- a/.config/PoliCheckExclusions.xml
+++ b/.config/PoliCheckExclusions.xml
@@ -1,3 +1,6 @@
 <PoliCheckExclusions>
-
+  <!-- https://eng.ms/docs/experiences-devices/customer-success-engineering/global/language-as-a-service/validationservices/policheck-for-microsoft/policheckclient/features/features#false-positive-management -->
+  <Exclusion Type="FileName">angular.min.js</Exclusion>
+  <Exclusion Type="FileName">bootstrap.min.js</Exclusion>
+  <Exclusion Type="FileName">jquery.min.js</Exclusion>
 </PoliCheckExclusions>

--- a/.config/PoliCheckExclusions.xml
+++ b/.config/PoliCheckExclusions.xml
@@ -1,6 +1,4 @@
 <PoliCheckExclusions>
   <!-- https://eng.ms/docs/experiences-devices/customer-success-engineering/global/language-as-a-service/validationservices/policheck-for-microsoft/policheckclient/features/features#false-positive-management -->
   <Exclusion Type="FileName">angular.min.js</Exclusion>
-  <Exclusion Type="FileName">bootstrap.min.js</Exclusion>
-  <Exclusion Type="FileName">jquery.min.js</Exclusion>
 </PoliCheckExclusions>

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -33,6 +33,12 @@ extends:
       policheck:
         enabled: true
         exclusionsFile: $(Build.SourcesDirectory)\.config\PoliCheckExclusions.xml
+      eslint:
+        enabled: true
+        enableExclusions: true
+        exclusionPatterns: |
+          **/jquery*.js
+          **/angular*.js
       sbom:
        # opting-out of SBOM generation as we don't produce artifacts
         enabled: false


### PR DESCRIPTION
* Get policheck clean by excluding angular.min.js, which we don't control.
* Get eslint clean by excluding jquery and angular.

I need to test this by running a pipeline, before merging.