### PR TITLE
Update the Node sample to use the dev cert

### DIFF
--- a/samples/AspireWithNode/AspireWithNode.AppHost/AspireWithNode.AppHost.csproj
+++ b/samples/AspireWithNode/AspireWithNode.AppHost/AspireWithNode.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Sdk Name="Aspire.AppHost.Sdk" Version="9.0.0-rc.1.24511.1" />
 
@@ -9,6 +9,10 @@
     <Nullable>enable</Nullable>
     <IsAspireHost>true</IsAspireHost>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\Shared\DevCertHostingExtensions.cs" Link="DevCertHostingExtensions.cs" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.AppHost" Version="9.0.0-rc.1.24511.1" />

--- a/samples/AspireWithNode/AspireWithNode.AppHost/NodeHostingExtensions.cs
+++ b/samples/AspireWithNode/AspireWithNode.AppHost/NodeHostingExtensions.cs
@@ -1,0 +1,27 @@
+﻿namespace Aspire.Hosting;
+
+internal static class NodeHostingExtensions
+{
+    /// <summary>
+    /// Injects the ASP.NET Core HTTPS developer certificate into the resource via the specified environment variables when
+    /// <paramref name="builder"/>.<see cref="IResourceBuilder{T}.ApplicationBuilder">ApplicationBuilder</see>.<see cref="IDistributedApplicationBuilder.ExecutionContext">ExecutionContext</see>.<see cref="DistributedApplicationExecutionContext.IsRunMode">IsRunMode</see><c> == true</c>.<br/>
+    /// </summary>
+    /// <remarks>
+    /// This method <strong>does not</strong> configure an HTTPS endpoint on the resource. Use <see cref="ResourceBuilderExtensions.WithHttpsEndpoint{TResource}"/> to configure an HTTPS endpoint.
+    /// </remarks>
+    public static IResourceBuilder<NodeAppResource> RunWithHttpsDevCertificate(this IResourceBuilder<NodeAppResource> builder, string? certFileEnv = null, string? certKeyFileEnv = null)
+    {
+        certFileEnv ??= "HTTPS_CERT_FILE";
+        certKeyFileEnv ??= "HTTPS_CERT_KEY_FILE";
+
+        DevCertHostingExtensions.RunWithHttpsDevCertificate(builder, certFileEnv, certKeyFileEnv);
+
+        builder.WithEnvironment(context =>
+        {
+            var certPath = context.EnvironmentVariables[certFileEnv];
+            context.EnvironmentVariables["NODE_EXTRA_CA_CERTS"] = certPath;
+        });
+
+        return builder;
+    }
+}

--- a/samples/AspireWithNode/AspireWithNode.AppHost/Program.cs
+++ b/samples/AspireWithNode/AspireWithNode.AppHost/Program.cs
@@ -20,9 +20,7 @@ var launchProfile = builder.Configuration["DOTNET_LAUNCH_PROFILE"] ??
 
 if (builder.Environment.IsDevelopment() && launchProfile == "https")
 {
-    frontend
-        .RunWithHttpsDevCertificate("HTTPS_CERT_FILE", "HTTPS_CERT_KEY_FILE")
-        .WithHttpsEndpoint(env: "HTTPS_PORT");
+    frontend.RunWithHttpsDevCertificate("HTTPS_CERT_FILE", "HTTPS_CERT_KEY_FILE");
 }
 
 builder.Build().Run();

--- a/samples/AspireWithNode/AspireWithNode.AppHost/Program.cs
+++ b/samples/AspireWithNode/AspireWithNode.AppHost/Program.cs
@@ -16,12 +16,13 @@ var frontend = builder.AddNpmApp("frontend", "../NodeFrontend", "watch")
     .PublishAsDockerFile();
 
 var launchProfile = builder.Configuration["DOTNET_LAUNCH_PROFILE"] ??
-    builder.Configuration["AppHost:DefaultLaunchProfileName"]; // work around https://github.com/dotnet/aspire/issues/5093
+                    builder.Configuration["AppHost:DefaultLaunchProfileName"]; // work around https://github.com/dotnet/aspire/issues/5093
 
 if (builder.Environment.IsDevelopment() && launchProfile == "https")
 {
-    // Disable TLS certificate validation in development, see https://github.com/dotnet/aspire/issues/3324 for more details.
-    frontend.WithEnvironment("NODE_TLS_REJECT_UNAUTHORIZED", "0");
+    frontend
+        .RunWithHttpsDevCertificate("HTTPS_CERT_FILE", "HTTPS_CERT_KEY_FILE")
+        .WithHttpsEndpoint(env: "HTTPS_PORT");
 }
 
 builder.Build().Run();

--- a/samples/AspireWithNode/NodeFrontend/app.js
+++ b/samples/AspireWithNode/NodeFrontend/app.js
@@ -29,7 +29,7 @@ const httpsOptions = fs.existsSync(config.certFile) && fs.existsSync(config.cert
     : { enabled: false };
 
 // Setup connection to Redis cache
-const passwordPrefix = ",password=";
+const passwordPrefix = ',password=';
 let cacheConfig = {
     url: `redis://${config.cacheAddress}`
 };
@@ -101,7 +101,7 @@ async function healthCheck() {
 // Start a server
 function startServer(server, port) {
     if (server) {
-        const serverType = server instanceof https.Server ? "HTTPS" : "HTTP";
+        const serverType = server instanceof https.Server ? 'HTTPS' : 'HTTP';
 
         // Create the health check endpoint
         createTerminus(server, {

--- a/samples/Shared/DevCertHostingExtensions.cs
+++ b/samples/Shared/DevCertHostingExtensions.cs
@@ -33,6 +33,7 @@ public static class DevCertHostingExtensions
                 if (!exported)
                 {
                     // The export failed for some reason, don't configure the resource to use the certificate.
+                    return;
                 }
 
                 if (builder.Resource is ContainerResource containerResource)

--- a/samples/Shared/DevCertHostingExtensions.cs
+++ b/samples/Shared/DevCertHostingExtensions.cs
@@ -75,7 +75,7 @@ public static class DevCertHostingExtensions
     {
         // Exports the ASP.NET Core HTTPS development certificate & private key to PEM files using 'dotnet dev-certs https' to a temporary
         // directory and returns the path.
-        // TODO: Check if we're running on a platform that already has the cert and key exported to a file (e.g. macOS) and just use those intead.
+        // TODO: Check if we're running on a platform that already has the cert and key exported to a file (e.g. macOS) and just use those instead.
         var appNameHash = builder.Configuration["AppHost:Sha256"]![..10];
         var tempDir = Path.Combine(Path.GetTempPath(), $"aspire.{appNameHash}");
         var certExportPath = Path.Combine(tempDir, "dev-cert.pem");
@@ -121,7 +121,7 @@ public static class DevCertHostingExtensions
             WindowStyle = ProcessWindowStyle.Hidden,
         };
 
-        var exportProcess = new Process() { StartInfo = exportStartInfo };
+        var exportProcess = new Process { StartInfo = exportStartInfo };
 
         Task? stdOutTask = null;
         Task? stdErrTask = null;

--- a/samples/Shared/DevCertHostingExtensions.cs
+++ b/samples/Shared/DevCertHostingExtensions.cs
@@ -1,4 +1,7 @@
 ﻿using System.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting;
 
@@ -10,46 +13,64 @@ public static class DevCertHostingExtensions
     /// If the resource is a <see cref="ContainerResource"/>, the certificate files will be bind mounted into the container.
     /// </summary>
     /// <remarks>
-    /// This method <strong>does not</strong> configure an HTTPS endpoint on the resource. Use <see cref="ResourceBuilderExtensions.WithHttpsEndpoint{TResource}"/> to configure an HTTPS endpoint.
+    /// This method <strong>does not</strong> configure an HTTPS endpoint on the resource.
+    /// Use <see cref="ResourceBuilderExtensions.WithHttpsEndpoint{TResource}"/> to configure an HTTPS endpoint.
     /// </remarks>
-    public static IResourceBuilder<TResource> RunWithHttpsDevCertificate<TResource>(this IResourceBuilder<TResource> builder, string certFileEnv, string certKeyFileEnv)
+    public static IResourceBuilder<TResource> RunWithHttpsDevCertificate<TResource>(
+        this IResourceBuilder<TResource> builder, string certFileEnv, string certKeyFileEnv, Action<string, string>? onSuccessfulExport = null)
         where TResource : IResourceWithEnvironment
     {
-        if (builder.ApplicationBuilder.ExecutionContext.IsRunMode)
+        if (builder.ApplicationBuilder.ExecutionContext.IsRunMode && builder.ApplicationBuilder.Environment.IsDevelopment())
         {
-            // Export the ASP.NET Core HTTPS devlopment certificate & private key to PEM files, bind mount them into the container
-            // and configure it to use them via the specified environment variables.
-            var (certPath, certKeyPath) = ExportDevCertificate(builder.ApplicationBuilder);
-
-            var certFileName = Path.GetFileName(certPath);
-            var certKeyFileName = Path.GetFileName(certKeyPath);
-
-            if (builder.Resource is ContainerResource containerResource)
+            builder.ApplicationBuilder.Eventing.Subscribe<BeforeStartEvent>(async (e, ct) =>
             {
-                const string DEV_CERT_BIND_MOUNT_DEST_DIR = "/dev-certs";
+                var logger = e.Services.GetRequiredService<ResourceLoggerService>().GetLogger(builder.Resource);
 
-                var bindSource = Path.GetDirectoryName(certPath) ?? throw new UnreachableException();
+                // Export the ASP.NET Core HTTPS development certificate & private key to files and configure the resource to use them via
+                // the specified environment variables.
+                var (exported, certPath, certKeyPath) = await TryExportDevCertificateAsync(builder.ApplicationBuilder, logger);
 
-                var certFileDest = Path.Combine(DEV_CERT_BIND_MOUNT_DEST_DIR, certFileName);
-                var certKeyFileDest = Path.Combine(DEV_CERT_BIND_MOUNT_DEST_DIR, certKeyFileName);
+                if (!exported)
+                {
+                    // The export failed for some reason, don't configure the resource to use the certificate.
+                }
 
-                builder.ApplicationBuilder.CreateResourceBuilder(containerResource)
-                    .WithBindMount(bindSource, DEV_CERT_BIND_MOUNT_DEST_DIR, isReadOnly: true)
-                    .WithEnvironment(certFileEnv, certFileDest)
-                    .WithEnvironment(certKeyFileEnv, certKeyFileDest);
-            }
-            else
-            {
-                builder
-                    .WithEnvironment(certFileEnv, certPath)
-                    .WithEnvironment(certKeyFileEnv, certKeyPath);
-            }
+                if (builder.Resource is ContainerResource containerResource)
+                {
+                    // Bind-mount the certificate files into the container.
+                    const string DEV_CERT_BIND_MOUNT_DEST_DIR = "/dev-certs";
+
+                    var certFileName = Path.GetFileName(certPath);
+                    var certKeyFileName = Path.GetFileName(certKeyPath);
+
+                    var bindSource = Path.GetDirectoryName(certPath) ?? throw new UnreachableException();
+
+                    var certFileDest = Path.Combine(DEV_CERT_BIND_MOUNT_DEST_DIR, certFileName);
+                    var certKeyFileDest = Path.Combine(DEV_CERT_BIND_MOUNT_DEST_DIR, certKeyFileName);
+
+                    builder.ApplicationBuilder.CreateResourceBuilder(containerResource)
+                        .WithBindMount(bindSource, DEV_CERT_BIND_MOUNT_DEST_DIR, isReadOnly: true)
+                        .WithEnvironment(certFileEnv, certFileDest)
+                        .WithEnvironment(certKeyFileEnv, certKeyFileDest);
+                }
+                else
+                {
+                    builder
+                        .WithEnvironment(certFileEnv, certPath)
+                        .WithEnvironment(certKeyFileEnv, certKeyPath);
+                }
+
+                if (onSuccessfulExport is not null)
+                {
+                    onSuccessfulExport(certPath, certKeyPath);
+                }
+            });
         }
 
         return builder;
     }
 
-    private static (string, string) ExportDevCertificate(IDistributedApplicationBuilder builder)
+    private static async Task<(bool, string CertFilePath, string CertKeyFilPath)> TryExportDevCertificateAsync(IDistributedApplicationBuilder builder, ILogger logger)
     {
         // Exports the ASP.NET Core HTTPS development certificate & private key to PEM files using 'dotnet dev-certs https' to a temporary
         // directory and returns the path.
@@ -62,49 +83,102 @@ public static class DevCertHostingExtensions
         if (File.Exists(certExportPath) && File.Exists(certKeyExportPath))
         {
             // Certificate already exported, return the path.
-            return (certExportPath, certKeyExportPath);
+            logger.LogDebug("Using previously exported dev cert files '{CertPath}' and '{CertKeyPath}'", certExportPath, certKeyExportPath);
+            return (true, certExportPath, certKeyExportPath);
         }
 
         if (File.Exists(certExportPath))
         {
+            logger.LogTrace("Deleting previously exported dev cert file '{CertPath}'", certExportPath);
             File.Delete(certExportPath);
         }
 
         if (File.Exists(certKeyExportPath))
         {
+            logger.LogTrace("Deleting previously exported dev cert key file '{CertKeyPath}'", certKeyExportPath);
             File.Delete(certKeyExportPath);
         }
 
         if (!Directory.Exists(tempDir))
         {
+            logger.LogTrace("Creating directory to export dev cert to '{ExportDir}'", tempDir);
             Directory.CreateDirectory(tempDir);
         }
 
         string[] args = ["dev-certs", "https", "--export-path", $"\"{certExportPath}\"", "--format", "Pem", "--no-password"];
         var argsString = string.Join(' ', args);
 
-        var exportProcess = Process.Start("dotnet", argsString);
+        logger.LogTrace("Running command to export dev cert: {ExportCmd}", $"dotnet {argsString}");
+        var exportStartInfo = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = argsString,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WindowStyle = ProcessWindowStyle.Hidden,
+        };
 
-        var exited = exportProcess.WaitForExit(TimeSpan.FromSeconds(5));
-        if (exited && File.Exists(certExportPath) && File.Exists(certKeyExportPath))
+        var exportProcess = new Process() { StartInfo = exportStartInfo };
+
+        Task? stdOutTask = null;
+        Task? stdErrTask = null;
+
+        try
         {
-            return (certExportPath, certKeyExportPath);
+            try
+            {
+                if (exportProcess.Start())
+                {
+                    stdOutTask = ConsumeOutput(exportProcess.StandardOutput, msg => logger.LogInformation("> {StandardOutput}", msg));
+                    stdErrTask = ConsumeOutput(exportProcess.StandardError, msg => logger.LogError("! {ErrorOutput}", msg));
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to start HTTPS dev certificate export process");
+                return default;
+            }
+
+            var timeout = TimeSpan.FromSeconds(5);
+            var exited = exportProcess.WaitForExit(timeout);
+
+            if (exited && File.Exists(certExportPath) && File.Exists(certKeyExportPath))
+            {
+                logger.LogDebug("Dev cert exported to '{CertPath}' and '{CertKeyPath}'", certExportPath, certKeyExportPath);
+                return (true, certExportPath, certKeyExportPath);
+            }
+
+            if (exportProcess.HasExited && exportProcess.ExitCode != 0)
+            {
+                logger.LogError("HTTPS dev certificate export failed with exit code {ExitCode}", exportProcess.ExitCode);
+            }
+            else if (!exportProcess.HasExited)
+            {
+                exportProcess.Kill(true);
+                logger.LogError("HTTPS dev certificate export timed out after {TimeoutSeconds} seconds", timeout.TotalSeconds);
+            }
+            else
+            {
+                logger.LogError("HTTPS dev certificate export failed for an unknown reason");
+            }
+            return default;
         }
-        else if (exportProcess.HasExited && exportProcess.ExitCode != 0)
+        finally
         {
-            throw new InvalidOperationException($"HTTPS dev certificate export failed with exit code {exportProcess.ExitCode}");
-        }
-        else if (!exportProcess.HasExited)
-        {
-            exportProcess.Kill(true);
-            throw new InvalidOperationException("HTTPS dev certificate export timed out");
+            await Task.WhenAll(stdOutTask ?? Task.CompletedTask, stdErrTask ?? Task.CompletedTask);
         }
 
-        throw new InvalidOperationException("HTTPS dev certificate export failed for an unknown reason");
+        static async Task ConsumeOutput(TextReader reader, Action<string> callback)
+        {
+            char[] buffer = new char[256];
+            int charsRead;
+
+            while ((charsRead = await reader.ReadAsync(buffer, 0, buffer.Length)) > 0)
+            {
+                callback(new string(buffer, 0, charsRead));
+            }
+        }
     }
-}
-
-public class DevCertAnnotation
-{
-
 }

--- a/samples/Shared/DevCertHostingExtensions.cs
+++ b/samples/Shared/DevCertHostingExtensions.cs
@@ -1,0 +1,110 @@
+﻿using System.Diagnostics;
+
+namespace Aspire.Hosting;
+
+public static class DevCertHostingExtensions
+{
+    /// <summary>
+    /// Injects the ASP.NET Core HTTPS developer certificate into the resource via the specified environment variables when
+    /// <paramref name="builder"/>.<see cref="IResourceBuilder{T}.ApplicationBuilder">ApplicationBuilder</see>.<see cref="IDistributedApplicationBuilder.ExecutionContext">ExecutionContext</see>.<see cref="DistributedApplicationExecutionContext.IsRunMode">IsRunMode</see><c> == true</c>.<br/>
+    /// If the resource is a <see cref="ContainerResource"/>, the certificate files will be bind mounted into the container.
+    /// </summary>
+    /// <remarks>
+    /// This method <strong>does not</strong> configure an HTTPS endpoint on the resource. Use <see cref="ResourceBuilderExtensions.WithHttpsEndpoint{TResource}"/> to configure an HTTPS endpoint.
+    /// </remarks>
+    public static IResourceBuilder<TResource> RunWithHttpsDevCertificate<TResource>(this IResourceBuilder<TResource> builder, string certFileEnv, string certKeyFileEnv)
+        where TResource : IResourceWithEnvironment
+    {
+        if (builder.ApplicationBuilder.ExecutionContext.IsRunMode)
+        {
+            // Export the ASP.NET Core HTTPS devlopment certificate & private key to PEM files, bind mount them into the container
+            // and configure it to use them via the specified environment variables.
+            var (certPath, certKeyPath) = ExportDevCertificate(builder.ApplicationBuilder);
+
+            var certFileName = Path.GetFileName(certPath);
+            var certKeyFileName = Path.GetFileName(certKeyPath);
+
+            if (builder.Resource is ContainerResource containerResource)
+            {
+                const string DEV_CERT_BIND_MOUNT_DEST_DIR = "/dev-certs";
+
+                var bindSource = Path.GetDirectoryName(certPath) ?? throw new UnreachableException();
+
+                var certFileDest = Path.Combine(DEV_CERT_BIND_MOUNT_DEST_DIR, certFileName);
+                var certKeyFileDest = Path.Combine(DEV_CERT_BIND_MOUNT_DEST_DIR, certKeyFileName);
+
+                builder.ApplicationBuilder.CreateResourceBuilder(containerResource)
+                    .WithBindMount(bindSource, DEV_CERT_BIND_MOUNT_DEST_DIR, isReadOnly: true)
+                    .WithEnvironment(certFileEnv, certFileDest)
+                    .WithEnvironment(certKeyFileEnv, certKeyFileDest);
+            }
+            else
+            {
+                builder
+                    .WithEnvironment(certFileEnv, certPath)
+                    .WithEnvironment(certKeyFileEnv, certKeyPath);
+            }
+        }
+
+        return builder;
+    }
+
+    private static (string, string) ExportDevCertificate(IDistributedApplicationBuilder builder)
+    {
+        // Exports the ASP.NET Core HTTPS development certificate & private key to PEM files using 'dotnet dev-certs https' to a temporary
+        // directory and returns the path.
+        // TODO: Check if we're running on a platform that already has the cert and key exported to a file (e.g. macOS) and just use those intead.
+        var appNameHash = builder.Configuration["AppHost:Sha256"]![..10];
+        var tempDir = Path.Combine(Path.GetTempPath(), $"aspire.{appNameHash}");
+        var certExportPath = Path.Combine(tempDir, "dev-cert.pem");
+        var certKeyExportPath = Path.Combine(tempDir, "dev-cert.key");
+
+        if (File.Exists(certExportPath) && File.Exists(certKeyExportPath))
+        {
+            // Certificate already exported, return the path.
+            return (certExportPath, certKeyExportPath);
+        }
+
+        if (File.Exists(certExportPath))
+        {
+            File.Delete(certExportPath);
+        }
+
+        if (File.Exists(certKeyExportPath))
+        {
+            File.Delete(certKeyExportPath);
+        }
+
+        if (!Directory.Exists(tempDir))
+        {
+            Directory.CreateDirectory(tempDir);
+        }
+
+        string[] args = ["dev-certs", "https", "--export-path", $"\"{certExportPath}\"", "--format", "Pem", "--no-password"];
+        var argsString = string.Join(' ', args);
+
+        var exportProcess = Process.Start("dotnet", argsString);
+
+        var exited = exportProcess.WaitForExit(TimeSpan.FromSeconds(5));
+        if (exited && File.Exists(certExportPath) && File.Exists(certKeyExportPath))
+        {
+            return (certExportPath, certKeyExportPath);
+        }
+        else if (exportProcess.HasExited && exportProcess.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"HTTPS dev certificate export failed with exit code {exportProcess.ExitCode}");
+        }
+        else if (!exportProcess.HasExited)
+        {
+            exportProcess.Kill(true);
+            throw new InvalidOperationException("HTTPS dev certificate export timed out");
+        }
+
+        throw new InvalidOperationException("HTTPS dev certificate export failed for an unknown reason");
+    }
+}
+
+public class DevCertAnnotation
+{
+
+}


### PR DESCRIPTION
Updates the Node.js sample to use the ASP.NET Core HTTPS dev certificate.

@mitchdenny @davidfowl you might want to take a look at the use of eventing here. I had some issues trying to achieve the method layering with anything other than the `BeforeStartEvent` but @davidfowl pointed out that work in that event blocks the dashboard from starting which is unfortunate but ultimately probably not a huge concern in this case. Specifically the need here is to do work (exporting the dev cert) that if successful results in changes to the resource (adding env vars, endpoints, bind mounts, and maybe more env vars that reference the added endpoints), and has access to a resource logger during that work.