### PR TITLE
Fix up Azure Functions sample for publishing

### DIFF
--- a/samples/AspireWithAzureFunctions/ImageGallery.AppHost/Program.cs
+++ b/samples/AspireWithAzureFunctions/ImageGallery.AppHost/Program.cs
@@ -10,8 +10,6 @@ var storage = builder.AddAzureStorage("storage").RunAsEmulator()
         // Storage Account Contributor and Storage Blob Data Owner roles are required by the Azure Functions host
         construct.Add(storageAccount.CreateRoleAssignment(StorageBuiltInRole.StorageAccountContributor, construct.PrincipalTypeParameter, construct.PrincipalIdParameter));
         construct.Add(storageAccount.CreateRoleAssignment(StorageBuiltInRole.StorageBlobDataOwner, construct.PrincipalTypeParameter, construct.PrincipalIdParameter));
-        // Anonymous access to Blobs required by the Blazor front-end
-        storageAccount.AllowBlobPublicAccess = true;
     });
 var blobs = storage.AddBlobs("blobs");
 var queues = storage.AddQueues("queues");

--- a/samples/AspireWithAzureFunctions/ImageGallery.AppHost/Program.cs
+++ b/samples/AspireWithAzureFunctions/ImageGallery.AppHost/Program.cs
@@ -10,6 +10,8 @@ var storage = builder.AddAzureStorage("storage").RunAsEmulator()
         // Storage Account Contributor and Storage Blob Data Owner roles are required by the Azure Functions host
         construct.Add(storageAccount.CreateRoleAssignment(StorageBuiltInRole.StorageAccountContributor, construct.PrincipalTypeParameter, construct.PrincipalIdParameter));
         construct.Add(storageAccount.CreateRoleAssignment(StorageBuiltInRole.StorageBlobDataOwner, construct.PrincipalTypeParameter, construct.PrincipalIdParameter));
+        // Ensure that public access to blobs is disabled
+        storageAccount.AllowBlobPublicAccess = false;
     });
 var blobs = storage.AddBlobs("blobs");
 var queues = storage.AddQueues("queues");

--- a/samples/AspireWithAzureFunctions/ImageGallery.AppHost/Program.cs
+++ b/samples/AspireWithAzureFunctions/ImageGallery.AppHost/Program.cs
@@ -1,17 +1,31 @@
-﻿var builder = DistributedApplication.CreateBuilder(args);
+﻿using Azure.Provisioning.Storage;
 
-var storage = builder.AddAzureStorage("storage").RunAsEmulator();
+var builder = DistributedApplication.CreateBuilder(args);
+
+var storage = builder.AddAzureStorage("storage").RunAsEmulator()
+    .ConfigureConstruct((ResourceModuleConstruct construct) =>
+    {
+        var storageAccount = construct.GetResources().OfType<StorageAccount>().FirstOrDefault(r => r.IdentifierName == "storage")
+            ?? throw new InvalidOperationException($"Could not find configured storage account with name 'storage'");
+        // Storage Account Contributor and Storage Blob Data Owner roles are required by the Azure Functions host
+        construct.Add(storageAccount.CreateRoleAssignment(StorageBuiltInRole.StorageAccountContributor, construct.PrincipalTypeParameter, construct.PrincipalIdParameter));
+        construct.Add(storageAccount.CreateRoleAssignment(StorageBuiltInRole.StorageBlobDataOwner, construct.PrincipalTypeParameter, construct.PrincipalIdParameter));
+        // Anonymous access to Blobs required by the Blazor front-end
+        storageAccount.AllowBlobPublicAccess = true;
+    });
 var blobs = storage.AddBlobs("blobs");
 var queues = storage.AddQueues("queues");
 
 var functions = builder.AddAzureFunctionsProject<Projects.ImageGallery_Functions>("functions")
                        .WithReference(queues)
                        .WithReference(blobs)
-                       .WaitFor(storage);
+                       .WaitFor(storage)
+                       .WithHostStorage(storage);
 
 builder.AddProject<Projects.ImageGallery_FrontEnd>("frontend")
        .WithReference(queues)
        .WithReference(blobs)
-       .WaitFor(functions);
+       .WaitFor(functions)
+       .WithExternalHttpEndpoints();
 
 builder.Build().Run();

--- a/samples/AspireWithAzureFunctions/ImageGallery.FrontEnd/Components/Pages/Home.razor.cs
+++ b/samples/AspireWithAzureFunctions/ImageGallery.FrontEnd/Components/Pages/Home.razor.cs
@@ -1,7 +1,7 @@
 ﻿using System.Net;
+using Microsoft.AspNetCore.Components.Forms;
 using Azure.Storage.Blobs;
 using ImageGallery.Shared;
-using Microsoft.AspNetCore.Components.Forms;
 
 namespace ImageGallery.FrontEnd.Components.Pages;
 
@@ -11,7 +11,7 @@ public sealed partial class Home(
     QueueMessageHandler queueMessageHandler,
     ILogger<Home> logger)
 {
-    private const long UploadFileSizeLimit = 524_288; // 512 KB (512 x 1024 bytes)
+    private const long UploadFileSizeLimitBytes = 524_288; // 512 KB (512 x 1024 bytes)
 
     private readonly HashSet<ImageViewModel> _images = [];
 
@@ -65,9 +65,9 @@ public sealed partial class Home(
                     continue;
                 }
 
-                if (file is { Size: > UploadFileSizeLimit })
+                if (file is { Size: > UploadFileSizeLimitBytes })
                 {
-                    _dialogMessage = $"File {file.Name} exceeds the size limit of {UploadFileSizeLimit} bytes.";
+                    _dialogMessage = $"File {file.Name} exceeds the size limit of {UploadFileSizeLimitBytes} bytes.";
                     OpenDialog();
 
                     continue;

--- a/samples/AspireWithAzureFunctions/ImageGallery.FrontEnd/Components/Pages/Home.razor.cs
+++ b/samples/AspireWithAzureFunctions/ImageGallery.FrontEnd/Components/Pages/Home.razor.cs
@@ -27,7 +27,7 @@ public sealed partial class Home(
 
     protected override async Task OnInitializedAsync()
     {
-        logger.LogInformation("Subscribing to message handler.");
+        logger.LogDebug("Subscribing to message handler.");
 
         await LoadBlobsAsync();
 
@@ -38,7 +38,7 @@ public sealed partial class Home(
     {
         try
         {
-            logger.LogInformation("Loading blobs...");
+            logger.LogDebug("Loading blobs...");
 
             await foreach (var blobItem in thumbsContainerClient.GetBlobsAsync())
             {
@@ -73,7 +73,7 @@ public sealed partial class Home(
                     continue;
                 }
 
-                logger.LogInformation("Uploading {Name}", file.Name);
+                logger.LogDebug("Uploading {Name}", file.Name);
 
                 var slug = ImageUrl.CreateNameSlug(file.Name);
                 var blobClient = imagesContainerClient.GetBlobClient(slug);

--- a/samples/AspireWithAzureFunctions/ImageGallery.FrontEnd/ImageUrl.cs
+++ b/samples/AspireWithAzureFunctions/ImageGallery.FrontEnd/ImageUrl.cs
@@ -1,0 +1,37 @@
+﻿namespace ImageGallery.FrontEnd;
+
+internal static class ImageUrl
+{
+    public static readonly string PathPrefix = "/images";
+    public static readonly string RoutePattern = PathPrefix + "/{slug}";
+
+    public static string GetImageUrl(string slug) => $"{PathPrefix}/{slug}";
+
+    public static string GetThumbnailUrl(string slug) => GetImageUrl(slug) + "?thumbnail=true";
+
+    public static string CreateNameSlug(string name)
+    {
+        var extension = Path.GetExtension(name);
+
+        var chars = name.AsSpan();
+        Span<char> buffer = stackalloc char[chars.Length];
+
+        // Replace invalid characters with '-'
+        // Valid chars are letters, digits, '-', and '_'
+        for (var i = 0; i < chars.Length - extension.Length; i++)
+        {
+            var c = chars[i];
+            buffer[i] = char.IsLetterOrDigit(c) || c == '-' || c == '_' ? c : '-';
+        }
+
+        // Add extension back
+        for (var i = 0; i < extension.Length; i++)
+        {
+            buffer[chars.Length - extension.Length + i] = extension[i];
+        }
+
+        var slug = new string(buffer);
+
+        return slug;
+    }
+}

--- a/samples/AspireWithAzureFunctions/ImageGallery.FrontEnd/ImageUrl.cs
+++ b/samples/AspireWithAzureFunctions/ImageGallery.FrontEnd/ImageUrl.cs
@@ -13,24 +13,21 @@ internal static class ImageUrl
     {
         var extension = Path.GetExtension(name);
 
-        var chars = name.AsSpan();
-        Span<char> buffer = stackalloc char[chars.Length];
+        var nameSpan = name.AsSpan();
+        Span<char> slugBuffer = stackalloc char[nameSpan.Length];
 
         // Replace invalid characters with '-'
         // Valid chars are letters, digits, '-', and '_'
-        for (var i = 0; i < chars.Length - extension.Length; i++)
+        for (var i = 0; i < nameSpan.Length - extension.Length; i++)
         {
-            var c = chars[i];
-            buffer[i] = char.IsLetterOrDigit(c) || c == '-' || c == '_' ? c : '-';
+            var c = nameSpan[i];
+            slugBuffer[i] = char.IsLetterOrDigit(c) || c == '-' || c == '_' ? c : '-';
         }
 
         // Add extension back
-        for (var i = 0; i < extension.Length; i++)
-        {
-            buffer[chars.Length - extension.Length + i] = extension[i];
-        }
+        nameSpan[^extension.Length..].CopyTo(slugBuffer[^extension.Length..]);
 
-        var slug = new string(buffer);
+        var slug = new string(slugBuffer);
 
         return slug;
     }

--- a/samples/AspireWithAzureFunctions/ImageGallery.FrontEnd/Program.cs
+++ b/samples/AspireWithAzureFunctions/ImageGallery.FrontEnd/Program.cs
@@ -2,8 +2,6 @@
 using Azure.Storage.Queues;
 using ImageGallery.FrontEnd;
 using ImageGallery.FrontEnd.Components;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Net.Http.Headers;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/samples/AspireWithAzureFunctions/ImageGallery.FrontEnd/Program.cs
+++ b/samples/AspireWithAzureFunctions/ImageGallery.FrontEnd/Program.cs
@@ -2,6 +2,8 @@
 using Azure.Storage.Queues;
 using ImageGallery.FrontEnd;
 using ImageGallery.FrontEnd.Components;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -42,5 +44,23 @@ app.UseAntiforgery();
 app.MapStaticAssets();
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();
+
+app.MapGet(ImageUrl.RoutePattern, async (string slug, bool? thumbnail, IServiceProvider services, CancellationToken cancellationToken) =>
+{
+    var containerClient = services.GetRequiredKeyedService<BlobContainerClient>(thumbnail == true ? "thumbnails" : "images");
+    var blobClient = containerClient.GetBlobClient(slug);
+
+    if (!await blobClient.ExistsAsync(cancellationToken))
+    {
+        return Results.NotFound();
+    }
+
+    var properties = (await blobClient.GetPropertiesAsync(cancellationToken: cancellationToken)).Value;
+
+    return Results.Stream(destination => blobClient.DownloadToAsync(destination, cancellationToken: cancellationToken),
+        contentType: properties.ContentType,
+        lastModified: properties.LastModified,
+        entityTag: new(properties.ETag.ToString("H")));
+});
 
 app.Run();

--- a/samples/AspireWithAzureFunctions/ImageGallery.FrontEnd/StorageWorker.cs
+++ b/samples/AspireWithAzureFunctions/ImageGallery.FrontEnd/StorageWorker.cs
@@ -19,8 +19,8 @@ public sealed class StorageWorker(
 
         await Task.WhenAll(
             thumbnailResultsQueueClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken),
-            imagesContainerClient.CreateIfNotExistsAsync(publicAccessType: PublicAccessType.Blob, cancellationToken: cancellationToken),
-            thumbsContainerClient.CreateIfNotExistsAsync(publicAccessType: PublicAccessType.Blob, cancellationToken: cancellationToken));
+            imagesContainerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken),
+            thumbsContainerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken));
 
         await base.StartAsync(cancellationToken);
     }

--- a/samples/AspireWithAzureFunctions/ImageGallery.FrontEnd/StorageWorker.cs
+++ b/samples/AspireWithAzureFunctions/ImageGallery.FrontEnd/StorageWorker.cs
@@ -36,7 +36,7 @@ public sealed class StorageWorker(
 
                 if (message is null or { Value: null })
                 {
-                    logger.LogInformation(
+                    logger.LogDebug(
                         "Message received but was either null or without value.");
 
                     continue;
@@ -47,7 +47,7 @@ public sealed class StorageWorker(
 
                 if (result is null or { IsSuccessful: false })
                 {
-                    logger.LogInformation(
+                    logger.LogWarning(
                         "Message upload result was either null or unsuccessful for {Name}.",
                         result?.Name);
 
@@ -64,7 +64,7 @@ public sealed class StorageWorker(
             }
             finally
             {
-                await Task.Delay(7_500, stoppingToken);
+                await Task.Delay(TimeSpan.FromMilliseconds(7_500), stoppingToken);
             }
         }
     }

--- a/samples/AspireWithAzureFunctions/ImageGallery.Functions/ImageGallery.Functions.csproj
+++ b/samples/AspireWithAzureFunctions/ImageGallery.Functions/ImageGallery.Functions.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Aspire.Azure.Storage.Blobs" Version="9.0.0-rc.1.24511.1" />
     <PackageReference Include="Aspire.Azure.Storage.Queues" Version="9.0.0-rc.1.24511.1" />
     <PackageReference Include="SkiaSharp" Version="2.88.8" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ImageGallery.ServiceDefaults\ImageGallery.ServiceDefaults.csproj" />

--- a/samples/AspireWithAzureFunctions/ImageGallery.Functions/ThumbnailGenerator.cs
+++ b/samples/AspireWithAzureFunctions/ImageGallery.Functions/ThumbnailGenerator.cs
@@ -7,15 +7,15 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 using SkiaSharp;
 
-namespace ImageGalleryFunctions;
+namespace ImageGallery.Functions;
 
 public class ThumbnailGenerator(ILogger<ThumbnailGenerator> logger,
     QueueServiceClient queueServiceClient,
     BlobServiceClient blobServiceClient)
 {
-    private BlobContainerClient containerClient = blobServiceClient.GetBlobContainerClient("thumbnails");
-    private QueueClient resultsQueueClient = queueServiceClient.GetQueueClient("thumbnail-queue");
-    private const int targetHeight = 128;
+    private readonly BlobContainerClient containerClient = blobServiceClient.GetBlobContainerClient("thumbnails");
+    private readonly QueueClient resultsQueueClient = queueServiceClient.GetQueueClient("thumbnail-queue");
+    private const int TargetHeight = 128;
 
     [Function(nameof(ThumbnailGenerator))]
     public async Task Resize([BlobTrigger("images/{name}", Connection = "blobs")] Stream stream, string name)
@@ -40,11 +40,11 @@ public class ThumbnailGenerator(ILogger<ThumbnailGenerator> logger,
     {
         using var originalBitmap = SKBitmap.Decode(stream);
 
-        var scale = (float)targetHeight / originalBitmap.Height;
+        var scale = (float)TargetHeight / originalBitmap.Height;
         var targetWidth = (int)(originalBitmap.Width * scale);
 
         using var resizedBitmap = originalBitmap.Resize(
-            new SKImageInfo(targetWidth, targetHeight), SKFilterQuality.High);
+            new SKImageInfo(targetWidth, TargetHeight), SKFilterQuality.High);
 
         using var image = SKImage.FromBitmap(resizedBitmap);
 
@@ -55,7 +55,7 @@ public class ThumbnailGenerator(ILogger<ThumbnailGenerator> logger,
 
         logger.LogInformation(
             "Resized image {Name} from {OriginalWidth}x{OriginalHeight} to {Width}x{Height}.",
-            name, originalBitmap.Width, originalBitmap.Height, targetWidth, targetHeight);
+            name, originalBitmap.Width, originalBitmap.Height, targetWidth, TargetHeight);
 
         return resizedStream;
     }

--- a/samples/AspireWithAzureFunctions/ImageGallery.Functions/ThumbnailGenerator.cs
+++ b/samples/AspireWithAzureFunctions/ImageGallery.Functions/ThumbnailGenerator.cs
@@ -13,8 +13,8 @@ public class ThumbnailGenerator(ILogger<ThumbnailGenerator> logger,
     QueueServiceClient queueServiceClient,
     BlobServiceClient blobServiceClient)
 {
-    private readonly BlobContainerClient containerClient = blobServiceClient.GetBlobContainerClient("thumbnails");
-    private readonly QueueClient resultsQueueClient = queueServiceClient.GetQueueClient("thumbnail-queue");
+    private readonly BlobContainerClient _containerClient = blobServiceClient.GetBlobContainerClient("thumbnails");
+    private readonly QueueClient _resultsQueueClient = queueServiceClient.GetQueueClient("thumbnail-queue");
     private const int TargetHeight = 128;
 
     [Function(nameof(ThumbnailGenerator))]
@@ -64,7 +64,7 @@ public class ThumbnailGenerator(ILogger<ThumbnailGenerator> logger,
     {
         resizedStream.Position = 0;
 
-        var blobClient = containerClient.GetBlobClient(name);
+        var blobClient = _containerClient.GetBlobClient(name);
 
         logger.LogDebug("Uploading {Name}", name);
 
@@ -80,7 +80,7 @@ public class ThumbnailGenerator(ILogger<ThumbnailGenerator> logger,
 
         logger.LogDebug("Signaling upload of {Name}", name);
 
-        await resultsQueueClient.SendMessageAsync(jsonMessage);
+        await _resultsQueueClient.SendMessageAsync(jsonMessage);
 
         logger.LogInformation("Signaled upload of {Name}", name);
     }

--- a/samples/AspireWithAzureFunctions/ImageGallery.Functions/ThumbnailGenerator.cs
+++ b/samples/AspireWithAzureFunctions/ImageGallery.Functions/ThumbnailGenerator.cs
@@ -66,7 +66,7 @@ public class ThumbnailGenerator(ILogger<ThumbnailGenerator> logger,
 
         var blobClient = containerClient.GetBlobClient(name);
 
-        logger.LogInformation("Uploading {Name}", name);
+        logger.LogDebug("Uploading {Name}", name);
 
         await blobClient.UploadAsync(resizedStream, overwrite: true);
 
@@ -78,7 +78,7 @@ public class ThumbnailGenerator(ILogger<ThumbnailGenerator> logger,
         var jsonMessage = JsonSerializer.Serialize(
             new UploadResult(name, true), SerializationContext.Default.UploadResult);
 
-        logger.LogInformation("Signaling upload of {Name}", name);
+        logger.LogDebug("Signaling upload of {Name}", name);
 
         await resultsQueueClient.SendMessageAsync(jsonMessage);
 

--- a/tests/SamplesIntegrationTests/AppHostTests.cs
+++ b/tests/SamplesIntegrationTests/AppHostTests.cs
@@ -45,11 +45,8 @@ public class AppHostTests(ITestOutputHelper testOutput)
         var projects = appHost.Resources.OfType<ProjectResource>();
         await using var app = await appHost.BuildAsync();
 
-        var startTask = app.StartAsync();
-        await startTask.WaitAsync(TimeSpan.FromSeconds(120));
-
-        var waitForResourcesTask = app.WaitForResourcesAsync();
-        await waitForResourcesTask.WaitAsync(TimeSpan.FromSeconds(120));
+        await app.StartAsync().WaitAsync(TimeSpan.FromSeconds(120));
+        await app.WaitForResourcesAsync().WaitAsync(TimeSpan.FromSeconds(120));
 
         if (testEndpoints.WaitForResources?.Count > 0)
         {

--- a/tests/SamplesIntegrationTests/AppHostTests.cs
+++ b/tests/SamplesIntegrationTests/AppHostTests.cs
@@ -25,11 +25,8 @@ public class AppHostTests(ITestOutputHelper testOutput)
         var appHost = await DistributedApplicationTestFactory.CreateAsync(appHostPath, testOutput);
         await using var app = await appHost.BuildAsync();
 
-        var startTask = app.StartAsync();
-        var waitForResourcesTask = app.WaitForResourcesAsync();
-
-        await startTask.WaitAsync(TimeSpan.FromSeconds(120));
-        await waitForResourcesTask.WaitAsync(TimeSpan.FromSeconds(120));
+        await app.StartAsync().WaitAsync(TimeSpan.FromSeconds(120));
+        await app.WaitForResourcesAsync().WaitAsync(TimeSpan.FromSeconds(120));
 
         app.EnsureNoErrorsLogged();
 
@@ -49,9 +46,9 @@ public class AppHostTests(ITestOutputHelper testOutput)
         await using var app = await appHost.BuildAsync();
 
         var startTask = app.StartAsync();
-        var waitForResourcesTask = app.WaitForResourcesAsync();
-
         await startTask.WaitAsync(TimeSpan.FromSeconds(120));
+
+        var waitForResourcesTask = app.WaitForResourcesAsync();
         await waitForResourcesTask.WaitAsync(TimeSpan.FromSeconds(120));
 
         if (testEndpoints.WaitForResources?.Count > 0)

--- a/tests/SamplesIntegrationTests/AppHostTests.cs
+++ b/tests/SamplesIntegrationTests/AppHostTests.cs
@@ -25,7 +25,11 @@ public class AppHostTests(ITestOutputHelper testOutput)
         var appHost = await DistributedApplicationTestFactory.CreateAsync(appHostPath, testOutput);
         await using var app = await appHost.BuildAsync();
 
-        await Task.WhenAll(app.StartAsync(), app.WaitForResourcesAsync()).WaitAsync(TimeSpan.FromSeconds(120));
+        var startTask = app.StartAsync();
+        var waitForResourcesTask = app.WaitForResourcesAsync();
+
+        await startTask.WaitAsync(TimeSpan.FromSeconds(120));
+        await waitForResourcesTask.WaitAsync(TimeSpan.FromSeconds(120));
 
         app.EnsureNoErrorsLogged();
 
@@ -44,7 +48,11 @@ public class AppHostTests(ITestOutputHelper testOutput)
         var projects = appHost.Resources.OfType<ProjectResource>();
         await using var app = await appHost.BuildAsync();
 
-        await Task.WhenAll(app.StartAsync(), app.WaitForResourcesAsync()).WaitAsync(TimeSpan.FromSeconds(120));
+        var startTask = app.StartAsync();
+        var waitForResourcesTask = app.WaitForResourcesAsync();
+
+        await startTask.WaitAsync(TimeSpan.FromSeconds(120));
+        await waitForResourcesTask.WaitAsync(TimeSpan.FromSeconds(120));
 
         if (testEndpoints.WaitForResources?.Count > 0)
         {

--- a/tests/SamplesIntegrationTests/Infrastructure/DistributedApplicationExtensions.cs
+++ b/tests/SamplesIntegrationTests/Infrastructure/DistributedApplicationExtensions.cs
@@ -136,9 +136,13 @@ public static partial class DistributedApplicationExtensions
             }
 
             logger.LogInformation("Wait for resource '{ResourceName}' completed with state '{ResourceState}'", resourceName, targetStateReached);
-            logger.LogInformation("Still waiting for resources [{Resources}] to reach one of target states [{TargetStates}].",
-                string.Join(',', resourceNames),
-                string.Join(',', targetStates));
+
+            if (resourceTasks.Count > 0)
+            {
+                logger.LogInformation("Still waiting for resources [{Resources}] to reach one of target states [{TargetStates}].",
+                    string.Join(',', resourceNames),
+                    string.Join(',', targetStates));
+            }
         }
 
         logger.LogInformation("Wait for all resources completed successfully!");


### PR DESCRIPTION
This PR fixes up a couple of issues with the Azure Functions sample that make it unpublishable:

- Enable external HTTP access on the Blazor front-end resource
- Configure the appropriate roles to support Blob triggers on the Azure Functions host
- Allow anonymous access to blobs in the storage account to support UI display in the Blazor front-end
- Reference `SkiaSharp.NativeAssets.Linux.NoDependencies` package to support running SkiaSharp in Linux containers on ACA