### PR TITLE
Improve the deployability of the container build sample

### DIFF
--- a/samples/ContainerBuild/ContainerBuild.AppHost/Program.cs
+++ b/samples/ContainerBuild/ContainerBuild.AppHost/Program.cs
@@ -2,18 +2,25 @@
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-var goVersion = builder.AddParameter("goversion", "1.22", publishValueAsDefault: true);
+// BUG: azd doesn't properly support parameters with default values yet
+//var goVersion = builder.AddParameter("goversion", "1.22", publishValueAsDefault: true);
+// Workaround: Default value used when running locally comes from appsettings.Development.json.
+//             A value must be provided when running azd up (use '1.22').
+var goVersion = builder.AddParameter("goversion");
 
 var ginapp = builder.AddDockerfile("ginapp", "../ginapp")
     .WithBuildArg("GO_VERSION", goVersion)
     .WithHttpEndpoint(targetPort: 5555, env: "PORT")
     .WithExternalHttpEndpoints();
 
-ginapp.WithEnvironment("TRUSTED_PROXIES", $"{ginapp.GetEndpoint("http").Property(EndpointProperty.Host)}");
-
-if (builder.ExecutionContext.IsRunMode || builder.Environment.IsProduction())
+if (builder.ExecutionContext.IsPublishMode || builder.Environment.IsProduction())
 {
-    ginapp.WithEnvironment("GIN_MODE", "release");
+    ginapp
+        .WithEnvironment("GIN_MODE", "release")
+        // Trust all proxies when running behind a reverse proxy. If deploying to an environment
+        // without a reverse proxy that ensures X-Forwarded-* headers are not forwarded from clients,
+        // this should be removed.
+        .WithEnvironment("TRUSTED_PROXIES", "all");
 }
 
 builder.Build().Run();

--- a/samples/ContainerBuild/ContainerBuild.AppHost/Program.cs
+++ b/samples/ContainerBuild/ContainerBuild.AppHost/Program.cs
@@ -3,6 +3,7 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
 // BUG: azd doesn't properly support parameters with default values yet
+//      https://github.com/Azure/azure-dev/issues/4523
 //var goVersion = builder.AddParameter("goversion", "1.22", publishValueAsDefault: true);
 // Workaround: Default value used when running locally comes from appsettings.Development.json.
 //             A value must be provided when running azd up (use '1.22').

--- a/samples/ContainerBuild/ContainerBuild.AppHost/appsettings.Development.json
+++ b/samples/ContainerBuild/ContainerBuild.AppHost/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+  "Parameters": {
+    "goversion": "1.22"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/samples/ContainerBuild/ContainerBuild.AppHost/appsettings.json
+++ b/samples/ContainerBuild/ContainerBuild.AppHost/appsettings.json
@@ -1,7 +1,4 @@
 {
-  "Parameters": {
-    "goversion": "1.23rc1"
-  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/samples/ContainerBuild/ginapp/ginapp.go
+++ b/samples/ContainerBuild/ginapp/ginapp.go
@@ -5,11 +5,21 @@ import (
     "fmt"
     "os"
     "strconv"
+    "strings"
 )
 
 func main() {
     // Create a Gin router with default middleware: logger and recovery (crash-free) middleware
     router := gin.Default()
+
+    // Configure trusted proxies
+    trustedProxies := os.Getenv("TRUSTED_PROXIES")
+    if trustedProxies != "" {
+        proxies := strings.Split(trustedProxies, ";")
+        router.SetTrustedProxies(proxies)
+    } else {
+        router.SetTrustedProxies(nil)
+    }
 
     // Define a route that listens to GET requests on /helloworld
     router.GET("/", func(c *gin.Context) {

--- a/samples/ContainerBuild/ginapp/ginapp.go
+++ b/samples/ContainerBuild/ginapp/ginapp.go
@@ -14,10 +14,14 @@ func main() {
 
     // Configure trusted proxies
     trustedProxies := os.Getenv("TRUSTED_PROXIES")
-    if trustedProxies != "" {
+    if trustedProxies == "all" {
+        // Trust all networks (default, no method call required)
+    } else if trustedProxies != "" {
+        // Trust specific networks
         proxies := strings.Split(trustedProxies, ";")
         router.SetTrustedProxies(proxies)
     } else {
+        // Disable trusted proxies
         router.SetTrustedProxies(nil)
     }
 
@@ -41,6 +45,7 @@ func main() {
     }
 
     endpoint := fmt.Sprintf(":%d", port);
+
     // Start the server
     router.Run(endpoint)
 }


### PR DESCRIPTION
- Ensure trusted proxies is explicitly configured in gin app
- Add workaround for azd not supporting default parameter values
- Mark HTTP endpoints on gin app as external
- Run gin app in release mode when published or in production

Contributes to #452