### PR TITLE
Make python app sample deployable

### DIFF
--- a/samples/AspireWithPython/AspireWithPython.AppHost/Program.cs
+++ b/samples/AspireWithPython/AspireWithPython.AppHost/Program.cs
@@ -1,7 +1,15 @@
-﻿var builder = DistributedApplication.CreateBuilder(args);
+﻿using Microsoft.Extensions.Hosting;
 
-builder.AddPythonApp("instrumented-python-app", "../InstrumentedPythonProject", "main.py")
-       .WithEndpoint(scheme: "http", env: "PORT")
+var builder = DistributedApplication.CreateBuilder(args);
+
+var pythonapp = builder.AddPythonApp("instrumented-python-app", "../InstrumentedPythonProject", "app.py")
+       .WithHttpEndpoint(env: "PORT")
+       .WithExternalHttpEndpoints()
        .WithOtlpExporter();
+
+if (builder.ExecutionContext.IsRunMode && builder.Environment.IsDevelopment())
+{
+    pythonapp.WithEnvironment("DEBUG", "True");
+}
 
 builder.Build().Run();

--- a/samples/AspireWithPython/InstrumentedPythonProject/Dockerfile
+++ b/samples/AspireWithPython/InstrumentedPythonProject/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.12.5-slim AS base
+
+# Set the working directory, the app files could be bind-mounted here
+WORKDIR /app
+
+# Copy the requirements file
+COPY requirements.txt .
+
+# Install dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Ensure the server is accessible from outside the container
+ENV HOST=0.0.0.0
+
+# Set the entry point to run the application 
+ENTRYPOINT ["opentelemetry-instrument", \
+    "--logs_exporter", "otlp", \
+    "--traces_exporter", "otlp", \
+    "--metrics_exporter", "otlp", \
+    "gunicorn", "--config", "gunicorn_config.py", "app:app"]
+
+CMD []
+
+FROM base AS publish
+
+COPY . .

--- a/samples/AspireWithPython/InstrumentedPythonProject/app.py
+++ b/samples/AspireWithPython/InstrumentedPythonProject/app.py
@@ -26,5 +26,7 @@ def hello_world():
 
 if __name__ == '__main__':
     port = int(os.environ.get('PORT', 8111))
-    app.run(port=port, debug=True)
+    debug = bool(os.environ.get('DEBUG', False))
+    host = os.environ.get('HOST', '127.0.0.1')
+    app.run(port=port, debug=debug, host=host)
     

--- a/samples/AspireWithPython/InstrumentedPythonProject/gunicorn_config.py
+++ b/samples/AspireWithPython/InstrumentedPythonProject/gunicorn_config.py
@@ -1,0 +1,12 @@
+import os
+
+workers = int(os.environ.get('GUNICORN_PROCESSES', '1'))
+threads = int(os.environ.get('GUNICORN_THREADS', '2'))
+timeout = int(os.environ.get('GUNICORN_TIMEOUT', '120'))
+host = os.environ.get('HOST', '127.0.0.1')
+port = os.environ.get('PORT', '8000')
+bind = f'{host}:{port}'
+
+forwarded_allow_ips = '*'
+
+secure_scheme_headers = { 'X-Forwarded-Proto': 'https' }

--- a/samples/AspireWithPython/InstrumentedPythonProject/requirements.txt
+++ b/samples/AspireWithPython/InstrumentedPythonProject/requirements.txt
@@ -2,3 +2,4 @@ Flask==3.0.3
 opentelemetry-distro
 opentelemetry-exporter-otlp-proto-grpc
 opentelemetry-instrumentation-flask
+gunicorn


### PR DESCRIPTION
- Add a Dockerfile
- Configure published app to use gunicorn WSGI server
- Mark Python app external
- Rename main.py to app.py (more inline with online tutorials)

App now deploys to ACA using azd successfully and emits OTel data:

![image](https://github.com/user-attachments/assets/d0a98c8a-8d9c-410a-8245-b0feb3967a74)

Fixes #530