### PR TITLE
Make AspireShop deployable

### DIFF
--- a/samples/AspireShop/AspireShop.AppHost/Program.cs
+++ b/samples/AspireShop/AspireShop.AppHost/Program.cs
@@ -1,8 +1,13 @@
 ﻿var builder = DistributedApplication.CreateBuilder(args);
 
 var postgres = builder.AddPostgres("postgres")
-    .WithDataVolume()
     .WithPgAdmin();
+
+if (builder.ExecutionContext.IsRunMode)
+{
+    // Data volumes don't work on ACA for Postgres so only add when running
+    postgres.WithDataVolume();
+}
 
 var catalogDb = postgres.AddDatabase("catalogdb");
 


### PR DESCRIPTION
Postgres doesn't work in ACA when using a data volume so only add it when in run mode.

Fixes #433