### PR TITLE
Fixed AspireShop paging

### DIFF
--- a/samples/AspireShop/AspireShop.Frontend/Services/CatalogServiceClient.cs
+++ b/samples/AspireShop/AspireShop.Frontend/Services/CatalogServiceClient.cs
@@ -15,7 +15,7 @@ public class CatalogServiceClient(HttpClient client)
             _ => throw new InvalidOperationException(),
         };
 
-        return client.GetFromJsonAsync<CatalogItemsPage>($"api/v1/catalog/items/type/all/brand{query}");
+        return client.GetFromJsonAsync<CatalogItemsPage>($"api/v1/catalog/items/type/all{query}");
     }
 }
 


### PR DESCRIPTION
Fixed the keyset pagination implementation ([source doc for reference](https://use-the-index-luke.com/no-offset)). In short, you have to order the query differently depending on whether you're navigating forward or backward.

Also tweaked CatalogAPI shape for better OpenAPI/Swagger experience.

https://github.com/user-attachments/assets/d0af0195-0f4a-4979-8e4a-4fdee0871eae

Fixes #322