### PR TITLE
Remove workarounds in HealthChecksUI sample

### DIFF
--- a/samples/HealthChecksUI/HealthChecksUI.AppHost/Program.cs
+++ b/samples/HealthChecksUI/HealthChecksUI.AppHost/Program.cs
@@ -13,9 +13,7 @@ var webFrontend = builder.AddProject<Projects.HealthChecksUI_Web>("webfrontend")
 
 builder.AddHealthChecksUI("healthchecksui")
     .WithReference(apiService)
-    .WaitFor(apiService)
     .WithReference(webFrontend)
-    .WaitFor(webFrontend)
     // This will make the HealthChecksUI dashboard available from external networks when deployed.
     // In a production environment, you should consider adding authentication to the ingress layer
     // to restrict access to the dashboard.

--- a/samples/HealthChecksUI/HealthChecksUI.AppHost/Program.cs
+++ b/samples/HealthChecksUI/HealthChecksUI.AppHost/Program.cs
@@ -13,7 +13,9 @@ var webFrontend = builder.AddProject<Projects.HealthChecksUI_Web>("webfrontend")
 
 builder.AddHealthChecksUI("healthchecksui")
     .WithReference(apiService)
+    .WaitFor(apiService)
     .WithReference(webFrontend)
+    .WaitFor(webFrontend)
     // This will make the HealthChecksUI dashboard available from external networks when deployed.
     // In a production environment, you should consider adding authentication to the ingress layer
     // to restrict access to the dashboard.

--- a/samples/HealthChecksUI/HealthChecksUI.AppHost/aspire-manifest.json
+++ b/samples/HealthChecksUI/HealthChecksUI.AppHost/aspire-manifest.json
@@ -1,9 +1,10 @@
 {
+  "$schema": "https://json.schemastore.org/aspire-8.0.json",
   "resources": {
     "cache": {
       "type": "container.v0",
       "connectionString": "{cache.bindings.tcp.host}:{cache.bindings.tcp.port}",
-      "image": "docker.io/library/redis:7.2",
+      "image": "docker.io/library/redis:7.4",
       "bindings": {
         "tcp": {
           "scheme": "tcp",
@@ -21,7 +22,7 @@
         "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
         "OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY": "in_memory",
         "ASPNETCORE_FORWARDEDHEADERS_ENABLED": "true",
-        "ASPNETCORE_HTTP_PORTS": "8080;{apiservice.bindings.healthchecks.targetPort}",
+        "HTTP_PORTS": "{apiservice.bindings.http.targetPort};{apiservice.bindings.healthchecks.targetPort}",
         "HEALTHCHECKSUI_URLS": "{apiservice.bindings.healthchecks.url}/healthz"
       },
       "bindings": {
@@ -39,7 +40,7 @@
           "scheme": "http",
           "protocol": "tcp",
           "transport": "http",
-          "targetPort": 8081
+          "targetPort": 8000
         }
       }
     },
@@ -51,11 +52,11 @@
         "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
         "OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY": "in_memory",
         "ASPNETCORE_FORWARDEDHEADERS_ENABLED": "true",
+        "HTTP_PORTS": "{webfrontend.bindings.http.targetPort};{webfrontend.bindings.healthchecks.targetPort}",
         "ConnectionStrings__cache": "{cache.connectionString}",
         "services__apiservice__http__0": "{apiservice.bindings.http.url}",
         "services__apiservice__https__0": "{apiservice.bindings.https.url}",
         "services__apiservice__healthchecks__0": "{apiservice.bindings.healthchecks.url}",
-        "ASPNETCORE_HTTP_PORTS": "8080;{webfrontend.bindings.healthchecks.targetPort}",
         "HEALTHCHECKSUI_URLS": "{webfrontend.bindings.healthchecks.url}/healthz"
       },
       "bindings": {
@@ -75,7 +76,7 @@
           "scheme": "http",
           "protocol": "tcp",
           "transport": "http",
-          "targetPort": 8081
+          "targetPort": 8001
         }
       }
     },


### PR DESCRIPTION
Removes workarounds in the HealthChecksUI sample that should no longer be required now that dotnet/aspire#3786 and dotnet/aspire#3749 are fixed.

~NOTE: I'm currently deploying the sample via `azd` to ensure it still works. Will update here to confirm outcome once done.~

~OK so seems there's a regression from this change. I'll investigate:~

![image](https://github.com/user-attachments/assets/c5350a95-2d23-4a61-8125-94c60b9d9bc6)

LOL it came good after a few seconds 😄 
![image](https://github.com/user-attachments/assets/bc1d14c2-3aa8-4bd7-917c-b6b93716b1aa)

`azd up` output:

```
Packaging services (azd package)

Provisioning Azure resources (azd provision)
Provisioning Azure resources can take some time.

Subscription: ****
Location: ****

  You can view detailed progress in the Azure Portal:
  *****

  (✓) Done: Container Registry: acrrfuiqiqdyuxji (9.938s)
  (✓) Done: Log Analytics workspace: law-rfuiqiqdyuxji (18.178s)
  (✓) Done: Container Apps Environment: cae-rfuiqiqdyuxji (1m36.401s)

Deploying services (azd deploy)

  (✓) Done: Deploying service apiservice
  - Endpoint: https://apiservice.internal.delightfulbay-32d021f3.westus.azurecontainerapps.io/

  (✓) Done: Deploying service cache
  - Endpoint: https://cache.internal.delightfulbay-32d021f3.westus.azurecontainerapps.io/

  (✓) Done: Deploying service healthchecksui
  - Endpoint: https://healthchecksui.delightfulbay-32d021f3.westus.azurecontainerapps.io/

  (✓) Done: Deploying service webfrontend
  - Endpoint: https://webfrontend.delightfulbay-32d021f3.westus.azurecontainerapps.io/

  Aspire Dashboard: https://aspire-dashboard.ext.delightfulbay-32d021f3.westus.azurecontainerapps.io

SUCCESS: Your up workflow to provision and deploy to Azure completed in 5 minutes 4 seconds.
```
