### PR TITLE
configured public ingress

### DIFF
--- a/samples/OrleansVoting/OrleansVoting.AppHost/Program.cs
+++ b/samples/OrleansVoting/OrleansVoting.AppHost/Program.cs
@@ -9,6 +9,7 @@ var orleans = builder.AddOrleans("voting-cluster")
 builder.AddProject<Projects.OrleansVoting_Service>("voting-fe")
     .WithReference(orleans)
     .WaitFor(redis)
-    .WithReplicas(3);
+    .WithReplicas(3)
+    .WithExternalHttpEndpoints();
 
 builder.Build().Run();


### PR DESCRIPTION
After testing to make sure #148 is fixed with the latest `azd` and Aspire 9 bits, this fix was needed for exposing the UX via public ingress. 