### PR TITLE
Update version of Prometheus exporter

### DIFF
--- a/samples/Metrics/ServiceDefaults/Extensions.cs
+++ b/samples/Metrics/ServiceDefaults/Extensions.cs
@@ -68,8 +68,7 @@ public static class Extensions
 
         // The following lines enable the Prometheus exporter (requires the OpenTelemetry.Exporter.Prometheus.AspNetCore package)
         builder.Services.AddOpenTelemetry()
-            // BUG: Part of the workaround for https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1617
-           .WithMetrics(metrics => metrics.AddPrometheusExporter(options => options.DisableTotalNameSuffixForCounters = true));
+           .WithMetrics(metrics => metrics.AddPrometheusExporter());
 
         return builder;
     }

--- a/samples/Metrics/ServiceDefaults/ServiceDefaults.csproj
+++ b/samples/Metrics/ServiceDefaults/ServiceDefaults.csproj
@@ -13,8 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
-    <!-- BUG: 1.8.0-rc.1 breaks prometheus exporter so sticking to 1.8.0-beta.1 for now https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1617 -->
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.8.0-rc.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.10.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />


### PR DESCRIPTION
Updated the version of `OpenTelemetry.Exporter.Prometheus.AspNetCore` to fix connectivity issue.
`1.8.0-rc.1` => `1.10.0-beta.1`