### PR TITLE
Install .NET SDK in CI

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -55,6 +55,10 @@ extends:
         steps:
         - checkout: self
           clean: true
+        - task: UseDotNet@2
+          displayName: Install global.json SDK
+          inputs:
+            useGlobalJson: true
         - powershell: |
               ./build.cmd
           displayName: ./build.cmd


### PR DESCRIPTION
Builds have been failing because the 9.0.100 SDK isn't installed on the build machines - this should fix that going forward