### PR TITLE
Add missing directory creation to fix certificate export issue.

### DIFF
--- a/samples/Keycloak/Keycloak.AppHost/HostingExtensions.cs
+++ b/samples/Keycloak/Keycloak.AppHost/HostingExtensions.cs
@@ -86,7 +86,7 @@ public static class HostingExtensions
         {
             Directory.Delete(tempDir, recursive: true);
         }
-
+        Directory.CreateDirectory(tempDir);
         var exportProcess = Process.Start("dotnet", $"dev-certs https --export-path \"{certExportPath}\" --format Pem --no-password");
 
         var exited = exportProcess.WaitForExit(TimeSpan.FromSeconds(5));


### PR DESCRIPTION
Summary

This PR addresses issue  #416 related to an error that occurs during certificate export when the specified directory does not exist. The issue was caused by the lack of a check or creation step for the directory before attempting to export the certificate.
Root Cause

When exporting the certificate, the CertificateManager throws a System.InvalidOperationException if the target directory is missing. The error message highlights that the directory does not exist and emphasizes the need for careful permission settings when creating it.
Fix

    Added a line to ensure the target directory is created before exporting the certificate:

    Directory.CreateDirectory(tempDir);

Impact

This change prevents the InvalidOperationException and ensures smooth certificate export without requiring manual intervention to create the directory. It also aligns the process with best practices for error handling and directory management.
Testing

    Verified that the directory is created automatically if it does not exist.
    Confirmed successful certificate export without errors.

Additional Notes

This fix improves usability and reliability when working with certificate export functionalities. Feedback and further suggestions are welcome!