### PR TITLE
AspireShop: Simplify WithHttpCommand

### DIFF
--- a/samples/AspireShop/AspireShop.AppHost/Program.cs
+++ b/samples/AspireShop/AspireShop.AppHost/Program.cs
@@ -20,7 +20,7 @@ var catalogDbManager = builder.AddProject<Projects.AspireShop_CatalogDbManager>(
     .WithReference(catalogDb)
     .WaitFor(catalogDb)
     .WithHttpHealthCheck("/health")
-    .WithHttpsCommand("/reset-db", "Reset Database", iconName: "DatabaseLightning");
+    .WithHttpCommand("/reset-db", "Reset Database", iconName: "DatabaseLightning");
 
 var catalogService = builder.AddProject<Projects.AspireShop_CatalogService>("catalogservice")
     .WithReference(catalogDb)


### PR DESCRIPTION
Changes the AspireShop sample so that the `WithHttpCommand` works by default against endpoints named "https" or "http".

Fixes #677