### PR TITLE
Add devcontainer to this repo

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,11 +5,7 @@
 		"ghcr.io/devcontainers/features/azure-cli:1": {},
 		"ghcr.io/azure/azure-dev/azd:0": {},
 		"ghcr.io/devcontainers/features/docker-in-docker": {},
-		"ghcr.io/devcontainers/features/dotnet": {
-			"additionalVersions": [
-				"8.0.403"
-			]
-		},
+		"ghcr.io/dotnet/aspire-devcontainer-feature/dotnetaspire:1": {},
 		"ghcr.io/devcontainers/features/node:1": {},
 		"ghcr.io/devcontainers/features/python:1": {}
 	},
@@ -21,8 +17,6 @@
 	"customizations": {
 		"vscode": {
 			"extensions": [
-				"ms-dotnettools.csdevkit",
-				"ms-azuretools.vscode-bicep",
 				"ms-azuretools.azure-dev",
 				"GitHub.copilot",
 				"GitHub.copilot-chat"				
@@ -37,6 +31,5 @@
 			}
 		}
 	},
-"dotnet new install Aspire.ProjectTemplates::9.1.0 --force",
 	"postStartCommand": "dotnet dev-certs https --trust"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,44 @@
+{
+	"name": ".NET Aspire Samples",
+	"image": "mcr.microsoft.com/devcontainers/dotnet:dev-9.0-bookworm",
+	"features": {
+		"ghcr.io/devcontainers/features/azure-cli:1": {},
+		"ghcr.io/azure/azure-dev/azd:0": {},
+		"ghcr.io/devcontainers/features/docker-in-docker": {},
+		"ghcr.io/devcontainers/features/dotnet": {
+			"additionalVersions": [
+				"8.0.403"
+			]
+		},
+		"ghcr.io/devcontainers/features/node:1": {},
+		"ghcr.io/devcontainers/features/python:1": {}
+	},
+	"hostRequirements": {
+		"cpus": 8,
+		"memory": "32gb",
+		"storage": "64gb"
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-dotnettools.csdevkit",
+				"ms-azuretools.vscode-bicep",
+				"ms-azuretools.azure-dev",
+				"GitHub.copilot"
+			],
+			"settings": {
+				"remote.autoForwardPorts": true,
+				"remote.autoForwardPortsSource": "hybrid",
+				"remote.otherPortsAttributes": {
+					"onAutoForward": "ignore"
+				},
+				"dotnet.defaultSolution": "Aspire.sln"
+			}
+		}
+	},
+	"onCreateCommand": "dotnet restore",
+	"postStartCommand": "dotnet dev-certs https --trust",
+	"remoteEnv": {
+		"PATH": "${containerEnv:PATH}:/workspaces/aspire/artifacts/bin/Aspire.Cli/Debug/net8.0/"
+	}
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,8 @@
 				"ms-dotnettools.csdevkit",
 				"ms-azuretools.vscode-bicep",
 				"ms-azuretools.azure-dev",
-				"GitHub.copilot"
+				"GitHub.copilot",
+				"GitHub.copilot-chat"				
 			],
 			"settings": {
 				"remote.autoForwardPorts": true,
@@ -36,6 +37,6 @@
 			}
 		}
 	},
-	"onCreateCommand": "dotnet restore",
+"dotnet new install Aspire.ProjectTemplates::9.1.0 --force",
 	"postStartCommand": "dotnet dev-certs https --trust"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -37,8 +37,5 @@
 		}
 	},
 	"onCreateCommand": "dotnet restore",
-	"postStartCommand": "dotnet dev-certs https --trust",
-	"remoteEnv": {
-		"PATH": "${containerEnv:PATH}:/workspaces/aspire/artifacts/bin/Aspire.Cli/Debug/net8.0/"
-	}
+	"postStartCommand": "dotnet dev-certs https --trust"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,7 +32,7 @@
 				"remote.otherPortsAttributes": {
 					"onAutoForward": "ignore"
 				},
-				"dotnet.defaultSolution": "Aspire.sln"
+				"dotnet.defaultSolution": "samples/AspireShop/AspireShop.sln"
 			}
 		}
 	},

--- a/README.md
+++ b/README.md
@@ -50,3 +50,31 @@ We welcome contributions to this repository of samples related to official .NET 
 ## Code of conduct
 
 This project has adopted the code of conduct defined by the [Contributor Covenant](https://contributor-covenant.org) to clarify expected behavior in our community. For more information, see the [.NET Foundation Code of Conduct](https://www.dotnetfoundation.org/code-of-conduct).
+
+## Using Devcontainer and Codespaces
+
+This repository includes a devcontainer configuration to help you quickly set up a development environment using Visual Studio Code and GitHub Codespaces.
+
+### Setting up Devcontainer
+
+1. **Install Visual Studio Code**: If you haven't already, download and install [Visual Studio Code](https://code.visualstudio.com/).
+
+2. **Install Dev Containers extension**: Open Visual Studio Code and go to the Extensions view by clicking on the Extensions icon in the Activity Bar on the side of the window. Search for "Dev Containers" and install the extension.
+
+3. **Clone the repository**: Clone this repository to your local machine.
+
+4. **Open the repository in Visual Studio Code**: Open Visual Studio Code and use the `File > Open Folder` menu to open the folder where you cloned this repository.
+
+5. **Reopen in Container**: Once the repository is open, you should see a notification prompting you to reopen the folder in a container. Click the "Reopen in Container" button. If you don't see the notification, you can also use the `Remote-Containers: Reopen in Container` command from the Command Palette (Ctrl+Shift+P).
+
+### Using GitHub Codespaces
+
+1. **Open the repository on GitHub**: Navigate to this repository on GitHub.
+
+2. **Create a Codespace**: Click the "Code" button and then click the "Open with Codespaces" tab. Click the "New codespace" button to create a new Codespace.
+
+3. **Wait for the Codespace to start**: GitHub will set up a new Codespace with the devcontainer configuration defined in this repository. This may take a few minutes.
+
+4. **Start coding**: Once the Codespace is ready, you can start coding directly in your browser or open the Codespace in Visual Studio Code.
+
+The devcontainer configuration includes all the necessary tools and dependencies to run the samples in this repository. You can start coding and running the samples without having to install anything else on your local machine.


### PR DESCRIPTION
Fixes #739

Add devcontainer configuration to the repository to enable running samples via Codespaces.

* **Add `.devcontainer/devcontainer.json`**:
  - Set the `name` to ".NET Aspire Samples".
  - Use the `image` "mcr.microsoft.com/devcontainers/dotnet:dev-9.0-bookworm".
  - Add necessary `features` for the devcontainer.
  - Add `customizations` for VS Code extensions and settings.
  - Set `onCreateCommand` to "dotnet restore".
  - Set `postStartCommand` to "dotnet dev-certs https --trust".
  - Configure `remoteEnv` for the PATH.

* **Update `README.md`**:
  - Add a section about using devcontainer and Codespaces to run the samples.
  - Provide instructions on how to set up and use the devcontainer.
  - Include steps for setting up Devcontainer and using GitHub Codespaces.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dotnet/aspire-samples/pull/740?shareId=bfa7904d-41a5-49d7-9ed7-8ef398478e88).