### PR TITLE
Update devcontainer.json to include .NET 8

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,11 @@
 		"ghcr.io/azure/azure-dev/azd:0": {},
 		"ghcr.io/devcontainers/features/docker-in-docker": {},
 		"ghcr.io/dotnet/aspire-devcontainer-feature/dotnetaspire:1": {},
+		"ghcr.io/devcontainers/features/dotnet": {
+			"additionalVersions": [
+				"8.0.403"
+			]
+		},		
 		"ghcr.io/devcontainers/features/node:1": {},
 		"ghcr.io/devcontainers/features/python:1": {}
 	},


### PR DESCRIPTION
Need .NET 8 for a lot of these samples, dotnetaspire feature includes only .NET 9.