### PR TITLE
Bump python from 3.12.5-slim to 3.12.9-slim

### DIFF
--- a/samples/AspireWithPython/InstrumentedPythonProject/Dockerfile
+++ b/samples/AspireWithPython/InstrumentedPythonProject/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.5-slim AS base
+FROM python:3.12.9-slim AS base
 
 # Set the working directory, the app files could be bind-mounted here
 WORKDIR /app


### PR DESCRIPTION
This supersedes an internal PR opened by dependabot..

FYI: @DamianEdwards