### PR TITLE
Add .NET 8.0 runtime support to devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,11 @@
 		"ghcr.io/devcontainers/features/docker-in-docker": {},
 		"ghcr.io/dotnet/aspire-devcontainer-feature/dotnetaspire:1": {},
 		"ghcr.io/devcontainers/features/node:1": {},
-		"ghcr.io/devcontainers/features/python:1": {}
+		"ghcr.io/devcontainers/features/python:1": {},
+		"ghcr.io/devcontainers/features/dotnet:2": {
+			"version": "none",
+			"aspNetCoreRuntimeVersions": "8.0"
+		}
 	},
 	"hostRequirements": {
 		"cpus": 8,
@@ -19,7 +23,7 @@
 			"extensions": [
 				"ms-azuretools.azure-dev",
 				"GitHub.copilot",
-				"GitHub.copilot-chat"				
+				"GitHub.copilot-chat"
 			],
 			"settings": {
 				"remote.autoForwardPorts": true,


### PR DESCRIPTION
The samples still use `TargetFramework: net8.0` so it is necessary to have a .NET 8.0 runtime installed to run the samples. (The .NET 9.0 SDK only contains the .NET 9.0 runtime.)

The "version" field is set to "none" to avoid overwriting the SDK version from the base image.
The "aspNetCoreRuntimeVersions" matches the TFM used by the samples.