### PR TITLE
Update to latest package versions

### DIFF
--- a/samples/aspire-shop/AspireShop.AppHost/AspireShop.AppHost.csproj
+++ b/samples/aspire-shop/AspireShop.AppHost/AspireShop.AppHost.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.0.1" />
-    <PackageReference Include="Aspire.Hosting.Redis" Version="13.0.1" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.0.2" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="13.0.2" />
     <ProjectReference Include="..\AspireShop.BasketService\AspireShop.BasketService.csproj" />
     <ProjectReference Include="..\AspireShop.CatalogDbManager\AspireShop.CatalogDbManager.csproj" />
     <ProjectReference Include="..\AspireShop.CatalogService\AspireShop.CatalogService.csproj" />

--- a/samples/aspire-shop/AspireShop.BasketService/AspireShop.BasketService.csproj
+++ b/samples/aspire-shop/AspireShop.BasketService/AspireShop.BasketService.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore" Version="2.71.0" />
     <PackageReference Include="Grpc.AspNetCore.HealthChecks" Version="2.71.0" />
-    <PackageReference Include="Aspire.StackExchange.Redis" Version="13.0.1" />
+    <PackageReference Include="Aspire.StackExchange.Redis" Version="13.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/aspire-shop/AspireShop.CatalogDb/AspireShop.CatalogDb.csproj
+++ b/samples/aspire-shop/AspireShop.CatalogDb/AspireShop.CatalogDb.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.0.1" />
+    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.0.2" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
   </ItemGroup>
 

--- a/samples/aspire-shop/AspireShop.CatalogDbManager/AspireShop.CatalogDbManager.csproj
+++ b/samples/aspire-shop/AspireShop.CatalogDbManager/AspireShop.CatalogDbManager.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.0.1" />
+    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/samples/aspire-shop/AspireShop.CatalogService/AspireShop.CatalogService.csproj
+++ b/samples/aspire-shop/AspireShop.CatalogService/AspireShop.CatalogService.csproj
@@ -13,7 +13,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
-    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.0.1" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.11.0" />
   </ItemGroup>
 

--- a/samples/aspire-with-azure-functions/ImageGallery.AppHost/ImageGallery.AppHost.csproj
+++ b/samples/aspire-with-azure-functions/ImageGallery.AppHost/ImageGallery.AppHost.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Azure.AppContainers" Version="13.0.1" />
-    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.0.1" />
-    <PackageReference Include="Aspire.Hosting.Azure.Functions" Version="13.0.1-preview.1.25575.3" />
+    <PackageReference Include="Aspire.Hosting.Azure.AppContainers" Version="13.0.2" />
+    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.0.2" />
+    <PackageReference Include="Aspire.Hosting.Azure.Functions" Version="13.0.2-preview.1.25603.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/aspire-with-azure-functions/ImageGallery.FrontEnd/ImageGallery.FrontEnd.csproj
+++ b/samples/aspire-with-azure-functions/ImageGallery.FrontEnd/ImageGallery.FrontEnd.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Azure.Storage.Queues" Version="13.0.1" />
-    <PackageReference Include="Aspire.Azure.Storage.Blobs" Version="13.0.1" />
+    <PackageReference Include="Aspire.Azure.Storage.Queues" Version="13.0.2" />
+    <PackageReference Include="Aspire.Azure.Storage.Blobs" Version="13.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/aspire-with-azure-functions/ImageGallery.Functions/ImageGallery.Functions.csproj
+++ b/samples/aspire-with-azure-functions/ImageGallery.Functions/ImageGallery.Functions.csproj
@@ -16,8 +16,8 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs" Version="6.8.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" Version="5.5.3" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
-    <PackageReference Include="Aspire.Azure.Storage.Blobs" Version="13.0.1" />
-    <PackageReference Include="Aspire.Azure.Storage.Queues" Version="13.0.1" />
+    <PackageReference Include="Aspire.Azure.Storage.Blobs" Version="13.0.2" />
+    <PackageReference Include="Aspire.Azure.Storage.Queues" Version="13.0.2" />
     <PackageReference Include="SkiaSharp" Version="3.119.1" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.1" />
   </ItemGroup>

--- a/samples/aspire-with-javascript/AspireJavaScript.AppHost/AspireJavaScript.AppHost.csproj
+++ b/samples/aspire-with-javascript/AspireJavaScript.AppHost/AspireJavaScript.AppHost.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
   <ProjectReference Include="..\AspireJavaScript.MinimalApi\AspireJavaScript.MinimalApi.csproj" />
-    <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.0.1" />
+    <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.0.2" />
   </ItemGroup>
 
 </Project>

--- a/samples/aspire-with-node/AspireWithNode.AppHost/AspireWithNode.AppHost.csproj
+++ b/samples/aspire-with-node/AspireWithNode.AppHost/AspireWithNode.AppHost.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\AspireWithNode.AspNetCoreApi\AspireWithNode.AspNetCoreApi.csproj" />
-    <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.0.1" />
-    <PackageReference Include="Aspire.Hosting.Redis" Version="13.0.1" />
+    <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.0.2" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="13.0.2" />
   </ItemGroup>
 
 </Project>

--- a/samples/database-containers/DatabaseContainers.ApiService/DatabaseContainers.ApiService.csproj
+++ b/samples/database-containers/DatabaseContainers.ApiService/DatabaseContainers.ApiService.csproj
@@ -12,9 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Microsoft.Data.SqlClient" Version="13.0.1" />
-    <PackageReference Include="Aspire.Npgsql" Version="13.0.1" />
-    <PackageReference Include="Aspire.MySqlConnector" Version="13.0.1" />
+    <PackageReference Include="Aspire.Microsoft.Data.SqlClient" Version="13.0.2" />
+    <PackageReference Include="Aspire.Npgsql" Version="13.0.2" />
+    <PackageReference Include="Aspire.MySqlConnector" Version="13.0.2" />
     <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.1" />
   </ItemGroup>

--- a/samples/database-containers/DatabaseContainers.AppHost/DatabaseContainers.AppHost.csproj
+++ b/samples/database-containers/DatabaseContainers.AppHost/DatabaseContainers.AppHost.csproj
@@ -17,9 +17,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.MySql" Version="13.0.1" />
-    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.0.1" />
-    <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.0.1" />
+    <PackageReference Include="Aspire.Hosting.MySql" Version="13.0.2" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.0.2" />
+    <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.0.2" />
   </ItemGroup>
 
 </Project>

--- a/samples/database-migrations/DatabaseMigrations.ApiService/DatabaseMigrations.ApiService.csproj
+++ b/samples/database-migrations/DatabaseMigrations.ApiService/DatabaseMigrations.ApiService.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.0.1" />
+    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.0.2" />
 
     <ProjectReference Include="..\DatabaseMigrations.ApiModel\DatabaseMigrations.ApiModel.csproj" />
     <ProjectReference Include="..\DatabaseMigrations.ServiceDefaults\DatabaseMigrations.ServiceDefaults.csproj" />

--- a/samples/database-migrations/DatabaseMigrations.AppHost/DatabaseMigrations.AppHost.csproj
+++ b/samples/database-migrations/DatabaseMigrations.AppHost/DatabaseMigrations.AppHost.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.0.1" />
+    <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/database-migrations/DatabaseMigrations.MigrationService/DatabaseMigrations.MigrationService.csproj
+++ b/samples/database-migrations/DatabaseMigrations.MigrationService/DatabaseMigrations.MigrationService.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.0.1" />
+    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.0.2" />
     <ProjectReference Include="..\DatabaseMigrations.ApiModel\DatabaseMigrations.ApiModel.csproj" />
     <ProjectReference Include="..\DatabaseMigrations.ServiceDefaults\DatabaseMigrations.ServiceDefaults.csproj" />
   </ItemGroup>

--- a/samples/health-checks-ui/HealthChecksUI.AppHost/HealthChecksUI.AppHost.csproj
+++ b/samples/health-checks-ui/HealthChecksUI.AppHost/HealthChecksUI.AppHost.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Docker" Version="13.0.1-preview.1.25575.3" />
-    <PackageReference Include="Aspire.Hosting.Redis" Version="13.0.1" />
+    <PackageReference Include="Aspire.Hosting.Docker" Version="13.0.2-preview.1.25603.5" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="13.0.2" />
   </ItemGroup>
 
 </Project>

--- a/samples/health-checks-ui/HealthChecksUI.Web/HealthChecksUI.Web.csproj
+++ b/samples/health-checks-ui/HealthChecksUI.Web/HealthChecksUI.Web.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.StackExchange.Redis.OutputCaching" Version="13.0.1" />
+    <PackageReference Include="Aspire.StackExchange.Redis.OutputCaching" Version="13.0.2" />
     <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
   </ItemGroup>
 

--- a/samples/orleans-voting/OrleansVoting.AppHost/OrleansVoting.AppHost.csproj
+++ b/samples/orleans-voting/OrleansVoting.AppHost/OrleansVoting.AppHost.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Redis" Version="13.0.1" />
-    <PackageReference Include="Aspire.Hosting.Orleans" Version="13.0.1" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="13.0.2" />
+    <PackageReference Include="Aspire.Hosting.Orleans" Version="13.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/orleans-voting/OrleansVoting.Service/OrleansVoting.Service.csproj
+++ b/samples/orleans-voting/OrleansVoting.Service/OrleansVoting.Service.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.StackExchange.Redis" Version="13.0.1" />
+    <PackageReference Include="Aspire.StackExchange.Redis" Version="13.0.2" />
 
     <PackageReference Include="Microsoft.Orleans.Clustering.Redis" Version="9.2.1" />
     <PackageReference Include="Microsoft.Orleans.Persistence.Redis" Version="9.2.1" />

--- a/samples/volume-mount/VolumeMount.AppHost/VolumeMount.AppHost.csproj
+++ b/samples/volume-mount/VolumeMount.AppHost/VolumeMount.AppHost.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Azure" Version="13.0.1" />
-    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.0.1" />
-    <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.0.1" />
+    <PackageReference Include="Aspire.Hosting.Azure" Version="13.0.2" />
+    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.0.2" />
+    <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/volume-mount/VolumeMount.BlazorWeb/VolumeMount.BlazorWeb.csproj
+++ b/samples/volume-mount/VolumeMount.BlazorWeb/VolumeMount.BlazorWeb.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Azure.Storage.Blobs" Version="13.0.1" />
-    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.0.1" />
+    <PackageReference Include="Aspire.Azure.Storage.Blobs" Version="13.0.2" />
+    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />

--- a/tests/SamplesIntegrationTests/SamplesIntegrationTests.csproj
+++ b/tests/SamplesIntegrationTests/SamplesIntegrationTests.csproj
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.0.1" />
-    <PackageReference Include="Aspire.Hosting.Azure" Version="13.0.1" />
-    <PackageReference Include="Aspire.Hosting.Testing" Version="13.0.1" />
-    <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.0.1" />
-    <PackageReference Include="Aspire.Hosting.Python" Version="13.0.1" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.0.2" />
+    <PackageReference Include="Aspire.Hosting.Azure" Version="13.0.2" />
+    <PackageReference Include="Aspire.Hosting.Testing" Version="13.0.2" />
+    <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.0.2" />
+    <PackageReference Include="Aspire.Hosting.Python" Version="13.0.2" />
 
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Updates to Aspire 13.0.2 and removes a direct dependency in AspireShop where it isn't needed and was causing package downgrades when dependabot tried to do updates.