### PR TITLE
Add policies to label and auto-merge Dependabot PRs

### DIFF
--- a/.github/policies/auto-merge.yml
+++ b/.github/policies/auto-merge.yml
@@ -1,0 +1,36 @@
+id: auto.merge
+name: GitOps.PullRequestIssueManagement
+description: Auto-merge pull requests labeled 'auto-merge' once CI is green
+owner:
+resource: repository
+disabled: false
+where:
+configuration:
+  resourceManagementConfiguration:
+    eventResponderTasks:
+
+      - description: >-
+          Approve and auto-squash-merge PRs to main labeled 'auto-merge'.
+          The label is only applied automatically to Dependabot PRs (see label-prs.yml),
+          so this effectively gates auto-merge to bot-authored or maintainer-opted-in PRs.
+          GitHub will only complete the merge once all required status checks pass.
+        triggerOnOwnActions: true
+        if:
+          - payloadType: Pull_Request
+          - labelAdded:
+              label: auto-merge
+          - targetsBranch:
+              branch: main
+        then:
+          - enableAutoMerge:
+              mergeMethod: Squash
+          - approvePullRequest:
+              comment: "Approved; this PR will merge when all required status checks pass."
+
+      - description: Disable auto-merge when the 'auto-merge' label is removed
+        if:
+          - payloadType: Pull_Request
+          - labelRemoved:
+              label: auto-merge
+        then:
+          - disableAutoMerge

--- a/.github/policies/label-prs.yml
+++ b/.github/policies/label-prs.yml
@@ -1,0 +1,42 @@
+id: label.prs
+name: GitOps.PullRequestIssueManagement
+description: Label management for pull requests
+owner:
+resource: repository
+disabled: false
+where:
+configuration:
+  resourceManagementConfiguration:
+    eventResponderTasks:
+
+      - description: >-
+          Label Dependabot pull requests with 'dependencies' and 'auto-merge'
+        if:
+          - payloadType: Pull_Request
+          - isAction:
+              action: Opened
+          - or:
+            - isActivitySender:
+                user: dependabot
+            - isActivitySender:
+                user: dependabot[bot]
+        then:
+          - addLabel:
+              label: dependencies
+          - addLabel:
+              label: auto-merge
+
+      - description: >-
+          Label Dependabot issues with 'dependencies'
+        if:
+          - payloadType: Issues
+          - isAction:
+              action: Opened
+          - or:
+            - isActivitySender:
+                user: dependabot
+            - isActivitySender:
+                user: dependabot[bot]
+        then:
+          - addLabel:
+              label: dependencies


### PR DESCRIPTION
Adds two GitOps policy configuration files under `.github/policies/` so that Dependabot pull requests are automatically labeled and auto-merged once CI is green.

Modeled after the equivalent policies in [dotnet/docs](https://github.com/dotnet/docs/tree/main/.github/policies).

### Files

- **`.github/policies/label-prs.yml`** — On open, labels Dependabot-authored PRs with `dependencies` and `auto-merge`, and Dependabot-authored issues with `dependencies`.
- **`.github/policies/auto-merge.yml`** — When a PR targeting `main` is labeled `auto-merge`, the bot approves it and enables GitHub's native auto-merge (squash). GitHub only completes the merge once all required status checks pass, so only green PRs land. Removing the label disables auto-merge.

### Why two files

This mirrors the structure used in dotnet/docs and keeps responsibilities separated:

- **Labeling** is the policy that decides *which* PRs are eligible for auto-merge (only Dependabot's, by default).
- **Auto-merge** is purely label-driven, so a maintainer can also opt a non-Dependabot PR in by adding the `auto-merge` label, or out by removing it.

### Behavior

- Only PRs targeting `main` are auto-merged.
- `triggerOnOwnActions: true` is set on the auto-merge rule so that the policy bot's own `labelAdded` event (from `label-prs.yml`) triggers the merge configuration.
- GitHub's branch protection / required checks remain the gate that determines "green"; this policy never bypasses CI.
