### PR TITLE
Secure and document the RAG sample

### DIFF
--- a/samples/rag-document-qa-svelte/README.md
+++ b/samples/rag-document-qa-svelte/README.md
@@ -40,6 +40,14 @@ aspire run
 
 Aspire will prompt for your OpenAI API key on first run.
 
+## Security Notes
+
+This is a local-first sample, not a production-ready document service. Uploaded documents are untrusted input and the API only accepts UTF-8 `.txt` text uploads with size, chunk, question length, and per-client rate limits to reduce accidental OpenAI cost or quota burn.
+
+RAG apps can be affected by prompt injection and data disclosure risks because retrieved document text is placed into model context. The sample does not provide tenant isolation, document deletion controls, malware/content scanning, or durable data-retention policies.
+
+Before adapting this for production, add real authentication and authorization, data retention and deletion workflows, monitoring, and malware/content scanning as appropriate for your data. Relevant references include [FastAPI security](https://fastapi.tiangolo.com/tutorial/security/), [OWASP LLM01 Prompt Injection](https://genai.owasp.org/llmrisk/llm01-prompt-injection/), [OWASP LLM02 Sensitive Information Disclosure](https://genai.owasp.org/llmrisk/llm022025-sensitive-information-disclosure/), [OWASP LLM08 Vector and Embedding Weaknesses](https://genai.owasp.org/llmrisk/llm082025-vector-and-embedding-weaknesses/), and OpenAI's [production best practices](https://developers.openai.com/api/docs/guides/production-best-practices) and [safety best practices](https://developers.openai.com/api/docs/guides/safety-best-practices).
+
 ## Commands
 
 ```bash

--- a/samples/rag-document-qa-svelte/api/main.py
+++ b/samples/rag-document-qa-svelte/api/main.py
@@ -40,7 +40,7 @@ MAX_QUESTION_LENGTH = 2000
 RATE_LIMIT_CAPACITY = 20
 RATE_LIMIT_REFILL_PER_SEC = 0.33  # ~20 requests per minute per client
 
-# Optional shared-secret auth. When RAG_API_KEY is set the mutating endpoints
+# Optional shared-secret auth. When RAG_API_KEY is set the protected endpoints
 # require callers to send the same value via the X-API-Key header. When it is
 # not set the sample stays anonymous (the other guards still apply) and a loud
 # warning is logged so deployments without auth are obvious.
@@ -52,8 +52,8 @@ _rate_lock = asyncio.Lock()
 
 if _api_key_required is None:
     logger.warning(
-        "RAG_API_KEY not set. /upload and /ask are anonymous; set RAG_API_KEY "
-        "before exposing this sample on a public network."
+        "RAG_API_KEY not set. /upload, /ask, and /documents are anonymous; "
+        "set RAG_API_KEY before exposing this sample on a public network."
     )
 
 
@@ -83,6 +83,25 @@ async def _enforce_rate_limit(request: Request) -> None:
                 detail="Rate limit exceeded. Please slow down.",
             )
         _rate_buckets[client_id] = (tokens - 1, now)
+
+
+def _validate_text_upload(file: UploadFile) -> None:
+    filename = file.filename or ""
+    if Path(filename).suffix.lower() != ".txt":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Only .txt text uploads are supported.",
+        )
+
+    content_type = (file.content_type or "").split(";", maxsplit=1)[0].strip().lower()
+    if content_type and not (
+        content_type.startswith("text/")
+        or content_type == "application/octet-stream"
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Uploaded file must be text content.",
+        )
 
 
 class QuestionRequest(BaseModel):
@@ -124,6 +143,8 @@ async def health():
 async def upload_document(file: UploadFile = File(...)):
     """Upload and index a document."""
     try:
+        _validate_text_upload(file)
+
         # Stream the upload in fixed-size chunks so we can reject oversized
         # payloads before they all sit in memory.
         buffered: list[bytes] = []
@@ -272,7 +293,7 @@ async def ask_question(request: QuestionRequest):
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@app.get("/documents")
+@app.get("/documents", dependencies=[Depends(_require_api_key)])
 async def list_documents():
     """List all indexed documents."""
     try:

--- a/samples/rag-document-qa-svelte/frontend/package.json
+++ b/samples/rag-document-qa-svelte/frontend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite dev --port $PORT --host",
+    "dev": "vite dev --port $PORT",
     "build": "vite build",
     "preview": "vite preview"
   },

--- a/samples/rag-document-qa-svelte/frontend/vite.config.js
+++ b/samples/rag-document-qa-svelte/frontend/vite.config.js
@@ -4,7 +4,7 @@ import { svelte } from '@sveltejs/vite-plugin-svelte'
 export default defineConfig({
   plugins: [svelte()],
   server: {
-    host: true,
+    host: 'localhost',
     proxy: {
       '/upload': {
         target: process.env.API_HTTP,


### PR DESCRIPTION
## Summary
- Require the optional `RAG_API_KEY` dependency on `GET /documents` so filenames are not enumerable when auth is configured.
- Add simple `.txt`/text upload validation while preserving anonymous sample behavior when `RAG_API_KEY` is unset.
- Add README Security Notes for uploaded document trust, prompt injection/RAG data disclosure risks, existing OpenAI cost controls, missing production controls, and official guidance links.
- Bind the RAG sample Vite dev server to localhost only in local run mode to avoid listening on external interfaces.

## Validation
- `python -m py_compile samples\rag-document-qa-svelte\api\main.py`
- `git --no-pager diff --check -- samples\rag-document-qa-svelte\api\main.py samples\rag-document-qa-svelte\README.md`
- `git --no-pager diff --check -- samples\rag-document-qa-svelte\frontend\package.json samples\rag-document-qa-svelte\frontend\vite.config.js`

## Aspire verification
- Command: from `samples\rag-document-qa-svelte`, ran `aspire run --detach --format Json --non-interactive --log-level Information` with a dummy local `Parameters__openai-api-key` value.
- Result: AppHost started successfully; `aspire wait qdrant`, `aspire wait api`, and `aspire wait frontend` all reported healthy.
- Resource summary after the loopback fix: `api` running/healthy at `https://localhost:50656`; `frontend` running/healthy at `http://localhost:50657/`; `qdrant` container running/healthy with HTTP/dashboard endpoints.
- HTTP checks: frontend returned `200`; API `/health` returned `{ "status": "healthy" }`.
- Loopback listener check: the RAG frontend Vite process command line was `vite.js dev --port $PORT --port 49240` with no `--host`, and `Get-NetTCPConnection -OwningProcess <vite-pid> -State Listen` showed only `127.0.0.1:49240`.
- Edge screenshot artifact: `C:\Users\dedward\.copilot\workspaces\6e41ca25-a7c4-4bc5-b45e-f7f7506fa243\artifacts\rag-document-qa-svelte-loopback-edge.png`.