### PR TITLE
Harden the C# PostgreSQL todo sample

### DIFF
--- a/samples/vite-csharp-postgres/README.md
+++ b/samples/vite-csharp-postgres/README.md
@@ -37,6 +37,14 @@ flowchart LR
 aspire run
 ```
 
+## Security Notes
+
+This sample is intentionally small and demo-focused. The todo CRUD endpoints under `/api/todos` are public and unauthenticated, and the app does not add authentication, authorization, CSRF protection, or rate limiting. `GET /api/todos` applies bounded pagination with `offset` and `limit` query parameters, defaulting to 50 items and capping responses at 100 items.
+
+The PostgreSQL pgAdmin container is included as local demo tooling. Do not expose pgAdmin or these unauthenticated CRUD endpoints directly in production.
+
+For production deployments, review the [ASP.NET Core security overview](https://learn.microsoft.com/aspnet/core/security/), add appropriate authentication and authorization, keep request validation in place using [ASP.NET Core minimal API parameter validation](https://learn.microsoft.com/aspnet/core/fundamentals/minimal-apis/parameter-binding?view=aspnetcore-10.0#parameter-validation), add [rate limiting](https://learn.microsoft.com/aspnet/core/performance/rate-limit), use [antiforgery APIs](https://learn.microsoft.com/aspnet/core/security/anti-request-forgery) when browser clients rely on cookies, and evaluate the [OWASP API Security Top 10](https://owasp.org/API-Security/editions/2023/en/0x11-t10/).
+
 ## Commands
 
 ```bash

--- a/samples/vite-csharp-postgres/api/Data/TodoDbContext.cs
+++ b/samples/vite-csharp-postgres/api/Data/TodoDbContext.cs
@@ -12,7 +12,7 @@ public class TodoDbContext(DbContextOptions<TodoDbContext> options) : DbContext(
         modelBuilder.Entity<Todo>(entity =>
         {
             entity.HasKey(e => e.Id);
-            entity.Property(e => e.Title).IsRequired().HasMaxLength(200);
+            entity.Property(e => e.Title).IsRequired().HasMaxLength(Todo.MaxTitleLength);
             entity.Property(e => e.Completed).IsRequired();
             entity.Property(e => e.CreatedAt).IsRequired();
         });

--- a/samples/vite-csharp-postgres/api/Extensions/TodoEndpoints.cs
+++ b/samples/vite-csharp-postgres/api/Extensions/TodoEndpoints.cs
@@ -6,14 +6,42 @@ namespace Api.Extensions;
 
 public static class TodoEndpoints
 {
+    private const int DefaultTodoLimit = 50;
+    private const int MaxTodoLimit = 100;
+
     public static WebApplication MapTodos(this WebApplication app)
     {
         var group = app.MapGroup("/api");
 
-        // Get all todos
-        group.MapGet("/todos", async (TodoDbContext db) =>
+        // Get todos
+        group.MapGet("/todos", async (int? offset, int? limit, TodoDbContext db) =>
         {
-            return await db.Todos.OrderBy(t => t.Id).ToListAsync();
+            var normalizedOffset = offset ?? 0;
+            var normalizedLimit = limit ?? DefaultTodoLimit;
+
+            if (normalizedOffset < 0)
+            {
+                return Results.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["offset"] = new[] { "Offset must be greater than or equal to 0." }
+                });
+            }
+
+            if (normalizedLimit is < 1 or > MaxTodoLimit)
+            {
+                return Results.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["limit"] = new[] { $"Limit must be between 1 and {MaxTodoLimit}." }
+                });
+            }
+
+            var todos = await db.Todos
+                .OrderBy(t => t.Id)
+                .Skip(normalizedOffset)
+                .Take(normalizedLimit)
+                .ToListAsync();
+
+            return Results.Ok(todos);
         });
 
         // Get todo by id
@@ -26,16 +54,22 @@ public static class TodoEndpoints
         // Create todo
         group.MapPost("/todos", async (CreateTodoRequest request, TodoDbContext db) =>
         {
+            var validationResult = ValidateTitle(request.Title, out var title);
+            if (validationResult is not null)
+            {
+                return validationResult;
+            }
+
             var todo = new Todo
             {
-                Title = request.Title,
+                Title = title,
                 Completed = false
             };
 
             db.Todos.Add(todo);
             await db.SaveChangesAsync();
 
-            return Results.Created($"/todos/{todo.Id}", todo);
+            return Results.Created($"/api/todos/{todo.Id}", todo);
         });
 
         // Update todo
@@ -49,7 +83,13 @@ public static class TodoEndpoints
 
             if (request.Title is not null)
             {
-                todo.Title = request.Title;
+                var validationResult = ValidateTitle(request.Title, out var title);
+                if (validationResult is not null)
+                {
+                    return validationResult;
+                }
+
+                todo.Title = title;
             }
 
             if (request.Completed is not null)
@@ -77,5 +117,28 @@ public static class TodoEndpoints
         });
 
         return app;
+    }
+
+    private static IResult? ValidateTitle(string? title, out string normalizedTitle)
+    {
+        normalizedTitle = title?.Trim() ?? string.Empty;
+
+        if (normalizedTitle.Length == 0)
+        {
+            return Results.ValidationProblem(new Dictionary<string, string[]>
+            {
+                ["title"] = new[] { "Title is required." }
+            });
+        }
+
+        if (normalizedTitle.Length > Todo.MaxTitleLength)
+        {
+            return Results.ValidationProblem(new Dictionary<string, string[]>
+            {
+                ["title"] = new[] { $"Title must be {Todo.MaxTitleLength} characters or fewer." }
+            });
+        }
+
+        return null;
     }
 }

--- a/samples/vite-csharp-postgres/api/Extensions/TodoEndpoints.cs
+++ b/samples/vite-csharp-postgres/api/Extensions/TodoEndpoints.cs
@@ -134,7 +134,7 @@ public static class TodoEndpoints
     {
         Dictionary<string, string[]> errors = new()
         {
-            [key] = new[] { message }
+            [key] = [message]
         };
 
         return Results.ValidationProblem(errors);

--- a/samples/vite-csharp-postgres/api/Extensions/TodoEndpoints.cs
+++ b/samples/vite-csharp-postgres/api/Extensions/TodoEndpoints.cs
@@ -21,18 +21,12 @@ public static class TodoEndpoints
 
             if (normalizedOffset < 0)
             {
-                return Results.ValidationProblem(new Dictionary<string, string[]>
-                {
-                    ["offset"] = new[] { "Offset must be greater than or equal to 0." }
-                });
+                return ValidationProblem("offset", "Offset must be greater than or equal to 0.");
             }
 
             if (normalizedLimit is < 1 or > MaxTodoLimit)
             {
-                return Results.ValidationProblem(new Dictionary<string, string[]>
-                {
-                    ["limit"] = new[] { $"Limit must be between 1 and {MaxTodoLimit}." }
-                });
+                return ValidationProblem("limit", $"Limit must be between 1 and {MaxTodoLimit}.");
             }
 
             var todos = await db.Todos
@@ -125,20 +119,24 @@ public static class TodoEndpoints
 
         if (normalizedTitle.Length == 0)
         {
-            return Results.ValidationProblem(new Dictionary<string, string[]>
-            {
-                ["title"] = new[] { "Title is required." }
-            });
+            return ValidationProblem("title", "Title is required.");
         }
 
         if (normalizedTitle.Length > Todo.MaxTitleLength)
         {
-            return Results.ValidationProblem(new Dictionary<string, string[]>
-            {
-                ["title"] = new[] { $"Title must be {Todo.MaxTitleLength} characters or fewer." }
-            });
+            return ValidationProblem("title", $"Title must be {Todo.MaxTitleLength} characters or fewer.");
         }
 
         return null;
+    }
+
+    private static IResult ValidationProblem(string key, string message)
+    {
+        Dictionary<string, string[]> errors = new()
+        {
+            [key] = new[] { message }
+        };
+
+        return Results.ValidationProblem(errors);
     }
 }

--- a/samples/vite-csharp-postgres/api/Models/Todo.cs
+++ b/samples/vite-csharp-postgres/api/Models/Todo.cs
@@ -2,6 +2,8 @@ namespace Api.Models;
 
 public class Todo
 {
+    public const int MaxTitleLength = 200;
+
     public int Id { get; set; }
     public required string Title { get; set; }
     public bool Completed { get; set; }

--- a/samples/vite-csharp-postgres/api/Models/TodoRequests.cs
+++ b/samples/vite-csharp-postgres/api/Models/TodoRequests.cs
@@ -1,4 +1,4 @@
 namespace Api.Models;
 
-public record CreateTodoRequest(string Title);
+public record CreateTodoRequest(string? Title);
 public record UpdateTodoRequest(string? Title, bool? Completed);

--- a/samples/vite-csharp-postgres/api/Services/DatabaseInitializer.cs
+++ b/samples/vite-csharp-postgres/api/Services/DatabaseInitializer.cs
@@ -19,7 +19,7 @@ public class DatabaseInitializer(IServiceProvider serviceProvider, ILogger<Datab
 
         try
         {
-            if ((await db.Database.GetMigrationsAsync(cancellationToken)).Any())
+            if (db.Database.GetMigrations().Any())
             {
                 _logger.LogInformation("[1/1] Applying migrations...");
                 await db.Database.MigrateAsync(cancellationToken);


### PR DESCRIPTION
## Summary
- Add bounded pagination to `GET /api/todos` with `offset` and capped `limit` query parameters.
- Validate todo titles on create/update for non-empty values and the configured maximum length.
- Fix the sample database initializer startup path by using the available EF Core migrations API.
- Document security notes for the public unauthenticated CRUD API, pgAdmin demo exposure, and production hardening recommendations with relevant links.

## Validation
- `dotnet build .\samples\vite-csharp-postgres\api\api.csproj --nologo` succeeded.

## Aspire verification
- Command: `cd samples\vite-csharp-postgres; aspire run --detach --format Json --non-interactive --nologo`
- Result: PASS. AppHost started successfully; `aspire wait` reported `postgres`, `db`, `api`, and `frontend` healthy.
- Resource status: `api` Running/Healthy, `db` Running/Healthy, `frontend` Running/Healthy, `pgadmin` Running/Healthy, `postgres` Running/Healthy, `frontend-installer` Finished.
- Resource URLs checked: Todo UI `http://localhost:53162/`; pgAdmin `http://localhost:53161`; PostgreSQL `tcp://localhost:53160`; API health `http://localhost:53178/health`; todo API `http://localhost:53178/api/todos?offset=0&limit=1`.
- Endpoint checks: bounded todo list returned HTTP 200; invalid `limit=101` returned HTTP 400 validation problem; empty title create returned HTTP 400 validation problem; valid todo create returned HTTP 201.
- Microsoft Edge screenshots saved locally: `C:\Users\dedward\.copilot\workspaces\84bf3a31-3081-4ab6-b009-d147e1041cd4\artifacts\vite-csharp-postgres-todo-ui.png`, `C:\Users\dedward\.copilot\workspaces\84bf3a31-3081-4ab6-b009-d147e1041cd4\artifacts\vite-csharp-postgres-pgadmin.png`.