### PR TITLE
Harden the Node Redis sample

### DIFF
--- a/samples/node-express-redis/README.md
+++ b/samples/node-express-redis/README.md
@@ -38,6 +38,14 @@ flowchart LR
 aspire run
 ```
 
+## Security Notes
+
+This sample keeps the Express endpoints public and unauthenticated so the visit counter is easy to run and inspect locally. It does not add CSRF protection, rate limiting, authentication, or authorization, so treat it as a demo pattern rather than production-ready API security.
+
+The API accepts visits only for the sample's built-in pages and uses bounded Redis operations for stats and reset. Production services still need deliberate cache and key management to avoid unbounded key cardinality, accidental deletion of unrelated keys, or expensive enumeration against shared Redis instances.
+
+For production applications, add real authN/authZ, request rate limiting, CSRF protection where browser credentials are used, bounded request bodies, and Redis security controls appropriate for your deployment. See the [Node.js security best practices](https://nodejs.org/en/learn/getting-started/security-best-practices), [Express body parser limits documentation](https://expressjs.com/en/resources/middleware/body-parser.html), [Redis security documentation](https://redis.io/docs/latest/operate/oss_and_stack/management/security/), and [OWASP API Security Top 10](https://owasp.org/API-Security/editions/2023/en/0x11-t10/).
+
 ## Commands
 
 ```bash

--- a/samples/node-express-redis/api/index.js
+++ b/samples/node-express-redis/api/index.js
@@ -3,8 +3,17 @@ import { createClient } from 'redis';
 
 const app = express();
 const port = process.env.PORT || 3000;
+const pages = ['home', 'about', 'contact', 'products', 'services', 'blog'];
+const allowedPages = new Set(pages);
+const visitKeyPrefix = 'sample:node-express-redis:visits:';
 
-app.use(express.json());
+function getVisitKey(page) {
+  return `${visitKeyPrefix}${page}`;
+}
+
+const visitKeys = pages.map((page) => getVisitKey(page));
+
+app.use(express.json({ limit: '10kb' }));
 
 // Initialize Redis client using Aspire connection properties
 // Aspire provides REDIS_URI for non-.NET apps
@@ -17,13 +26,17 @@ redis.on('connect', () => console.log('✓ Connected to Redis'));
 // Connect to Redis
 await redis.connect();
 
-async function getVisitKeys() {
-  const keys = [];
-  for await (const key of redis.scanIterator({ MATCH: 'visits:*', COUNT: 100 })) {
-    keys.push(key);
+function validatePage(req, res, next) {
+  const { page } = req.params;
+
+  if (!allowedPages.has(page)) {
+    return res.status(400).json({
+      error: 'Unsupported page',
+      allowedPages: pages,
+    });
   }
 
-  return keys;
+  next();
 }
 
 // Root endpoint
@@ -45,9 +58,9 @@ app.get('/health', async (req, res) => {
 });
 
 // Track a visit to a page
-app.post('/visit/:page', async (req, res) => {
+app.post('/visit/:page', validatePage, async (req, res) => {
   const { page } = req.params;
-  const count = await redis.incr(`visits:${page}`);
+  const count = await redis.incr(getVisitKey(page));
 
   res.json({
     page,
@@ -57,44 +70,39 @@ app.post('/visit/:page', async (req, res) => {
 });
 
 // Get visit count for a page
-app.get('/visit/:page', async (req, res) => {
+app.get('/visit/:page', validatePage, async (req, res) => {
   const { page } = req.params;
-  const count = await redis.get(`visits:${page}`);
+  const count = await redis.get(getVisitKey(page));
 
   res.json({
     page,
-    visits: count ? parseInt(count) : 0,
+    visits: count ? parseInt(count, 10) : 0,
   });
 });
 
 // Get stats for all pages
 app.get('/stats', async (req, res) => {
-  const keys = await getVisitKeys();
-  const counts = keys.length > 0 ? await redis.mGet(keys) : [];
+  const counts = await redis.mGet(visitKeys);
   const stats = {};
 
-  keys.forEach((key, index) => {
-    const page = key.replace('visits:', '');
+  pages.forEach((page, index) => {
     const count = counts[index];
     stats[page] = count ? parseInt(count, 10) : 0;
   });
 
   res.json({
-    totalPages: keys.length,
+    totalPages: pages.length,
     stats,
   });
 });
 
 // Reset all stats
 app.delete('/stats', async (req, res) => {
-  const keys = await getVisitKeys();
-  if (keys.length > 0) {
-    await redis.del(...keys);
-  }
+  const pagesCleared = await redis.del(...visitKeys);
 
   res.json({
     message: 'All stats reset',
-    pagesCleared: keys.length,
+    pagesCleared,
   });
 });
 

--- a/samples/node-express-redis/api/index.js
+++ b/samples/node-express-redis/api/index.js
@@ -106,6 +106,14 @@ app.delete('/stats', async (req, res) => {
   });
 });
 
+app.use((err, req, res, next) => {
+  if (err?.type === 'entity.too.large') {
+    return res.status(413).json({ error: 'Request body too large' });
+  }
+
+  next(err);
+});
+
 app.listen(port, () => {
   console.log(`✓ API listening on port ${port}`);
 });

--- a/samples/node-express-redis/frontend/vite.config.ts
+++ b/samples/node-express-redis/frontend/vite.config.ts
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   server: {
-    allowedHosts: ['host.docker.internal'],
+    allowedHosts: ['host.docker.internal', 'aspire.dev.internal'],
     host: true,
     proxy: {
       '/api': {


### PR DESCRIPTION
## Summary
- Bound Express JSON request bodies with an explicit 10kb limit and return a concise JSON 413 response for oversized bodies.
- Validate visit `:page` values against the sample UI page allowlist.
- Replace open-ended Redis `SCAN`/delete behavior with fixed sample-owned keys for the default pages.
- Allow Aspire's YARP container host (`aspire.dev.internal`) in Vite without disabling Vite host checking, so the run-mode app resource serves the UI.
- Add README Security Notes with production guidance and links to Node.js, Express body parser, Redis, and OWASP API security docs.

## Validation
- `node --check samples\\node-express-redis\\api\\index.js` ✅
- `npm --prefix samples\\node-express-redis run aspire:build` ✅
- `npm --prefix samples\\node-express-redis run aspire:lint` ❌ existing ESLint project service config does not include `apphost.ts`
- `npm --prefix samples\\node-express-redis\\frontend run build` ❌ existing TypeScript config lacks declarations for `./style.css` side-effect import

## Aspire verification
- Command: `aspire run --detach --format Json --non-interactive --isolated` from `samples\\node-express-redis`, then `aspire resource app start --non-interactive`.
- Browser check: Playwright CLI with Microsoft Edge channel only: `npx playwright screenshot --browser chromium --channel msedge --ignore-https-errors --wait-for-selector h1 https://localhost:51198 ...`.
- Result: PASS. `api`, `app`, `frontend`, `redis`, `redisinsight`, and `aspire-dashboard` reported `Running`/`Healthy`; installer resources reported `Finished`.
- Resource URLs: app `https://localhost:51198` / `http://localhost:51201`; frontend `http://localhost:51197`; API `http://localhost:51200`; dashboard `https://localhost:48969/login?t=...`; Redis `tcp://localhost:51199` / `rediss://localhost:51196`; RedisInsight `https://localhost:51195`.
- Endpoint checks through YARP: `/` 200, `/api/health` 200, `POST /api/visit/home` 200, `/api/stats` returned six default pages, invalid page returned 400, oversized JSON returned 413.
- Screenshots were saved as Copilot session artifacts (`node-express-redis-app-yarp-edge.png`, `node-express-redis-frontend-edge.png`, `node-express-redis-dashboard-edge.png`).