### PR TITLE
Harden the Go API sample

### DIFF
--- a/samples/golang-api/README.md
+++ b/samples/golang-api/README.md
@@ -73,3 +73,19 @@ else
 - `POST /items` - Create new item
 - `PUT /items/{id}` - Update item
 - `DELETE /items/{id}` - Delete item
+
+## Security Notes
+
+This sample keeps the API intentionally small for demo purposes:
+
+- It does not implement authentication or authorization.
+- Data is stored only in memory and is lost when the process restarts.
+- The request body, item name, and in-memory item count limits are illustrative safeguards, not production capacity planning.
+- External HTTP endpoints are enabled to make the demo easy to run and inspect.
+- Production services should add real authentication, authorization, rate limiting, persistent storage, and monitoring appropriate for their threat model.
+
+Related references:
+
+- [Go `net/http.Server` docs](https://pkg.go.dev/net/http#Server)
+- [Dockerfile best practices: user](https://docs.docker.com/build/building/best-practices/#user)
+- [OWASP API Security Top 10](https://owasp.org/API-Security/editions/2023/en/0x11-t10/)

--- a/samples/golang-api/api/Dockerfile
+++ b/samples/golang-api/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine AS builder
+FROM golang:1.23-alpine3.21 AS builder
 
 WORKDIR /app
 
@@ -9,12 +9,16 @@ RUN go mod download
 COPY . ./
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
 
-FROM alpine:latest
+FROM alpine:3.21
 
-RUN apk --no-cache add ca-certificates
+RUN apk --no-cache add ca-certificates \
+    && addgroup -S app \
+    && adduser -S -G app app
 
-WORKDIR /root/
+WORKDIR /app
 
 COPY --from=builder /app/main ./
+
+USER app
 
 CMD ["./main"]

--- a/samples/golang-api/api/Dockerfile
+++ b/samples/golang-api/api/Dockerfile
@@ -19,6 +19,8 @@ WORKDIR /app
 
 COPY --from=builder /app/main ./
 
+ENV HOST=0.0.0.0
+
 USER app
 
 CMD ["./main"]

--- a/samples/golang-api/api/main.go
+++ b/samples/golang-api/api/main.go
@@ -2,15 +2,30 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
+	"io"
 	"log"
 	"net/http"
 	"os"
 	"strconv"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+)
+
+const (
+	maxJSONRequestBodyBytes = 1 << 20
+	maxItemNameLength       = 200
+	maxStoredItems          = 1000
+)
+
+var (
+	errStoreFull        = errors.New("store is at capacity")
+	errItemNameRequired = errors.New("item name is required")
+	errItemNameTooLong  = errors.New("item name is too long")
 )
 
 type Item struct {
@@ -21,15 +36,17 @@ type Item struct {
 }
 
 type Store struct {
-	mu    sync.RWMutex
-	items map[int]*Item
-	nextID int
+	mu       sync.RWMutex
+	items    map[int]*Item
+	nextID   int
+	maxItems int
 }
 
-func NewStore() *Store {
+func NewStore(maxItems int) *Store {
 	return &Store{
-		items: make(map[int]*Item),
-		nextID: 1,
+		items:    make(map[int]*Item),
+		nextID:   1,
+		maxItems: maxItems,
 	}
 }
 
@@ -52,9 +69,17 @@ func (s *Store) Get(id int) (*Item, bool) {
 	return item, ok
 }
 
-func (s *Store) Create(name string) *Item {
+func (s *Store) Create(name string) (*Item, error) {
+	if err := validateItemName(name); err != nil {
+		return nil, err
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	if len(s.items) >= s.maxItems {
+		return nil, errStoreFull
+	}
 
 	item := &Item{
 		ID:        s.nextID,
@@ -64,16 +89,22 @@ func (s *Store) Create(name string) *Item {
 	}
 	s.items[s.nextID] = item
 	s.nextID++
-	return item
+	return item, nil
 }
 
-func (s *Store) Update(id int, name *string, completed *bool) (*Item, bool) {
+func (s *Store) Update(id int, name *string, completed *bool) (*Item, bool, error) {
+	if name != nil {
+		if err := validateItemName(*name); err != nil {
+			return nil, false, err
+		}
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	item, ok := s.items[id]
 	if !ok {
-		return nil, false
+		return nil, false, nil
 	}
 
 	if name != nil {
@@ -82,7 +113,7 @@ func (s *Store) Update(id int, name *string, completed *bool) (*Item, bool) {
 	if completed != nil {
 		item.Completed = *completed
 	}
-	return item, true
+	return item, true, nil
 }
 
 func (s *Store) Delete(id int) bool {
@@ -96,13 +127,72 @@ func (s *Store) Delete(id int) bool {
 	return ok
 }
 
+func validateItemName(name string) error {
+	if name == "" {
+		return errItemNameRequired
+	}
+	if utf8.RuneCountInString(name) > maxItemNameLength {
+		return errItemNameTooLong
+	}
+	return nil
+}
+
+func decodeJSONBody(w http.ResponseWriter, r *http.Request, dst any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxJSONRequestBodyBytes)
+
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(dst); err != nil {
+		writeJSONDecodeError(w, err)
+		return false
+	}
+
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		writeJSONDecodeError(w, err)
+		return false
+	}
+
+	return true
+}
+
+func writeJSONDecodeError(w http.ResponseWriter, err error) {
+	var maxBytesErr *http.MaxBytesError
+	if errors.As(err, &maxBytesErr) {
+		http.Error(w, "Request body too large", http.StatusRequestEntityTooLarge)
+		return
+	}
+
+	http.Error(w, "Invalid request body", http.StatusBadRequest)
+}
+
+func writeStoreError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, errItemNameRequired):
+		http.Error(w, "Name is required", http.StatusBadRequest)
+	case errors.Is(err, errItemNameTooLong):
+		http.Error(w, "Name is too long", http.StatusBadRequest)
+	case errors.Is(err, errStoreFull):
+		http.Error(w, "Item limit reached", http.StatusConflict)
+	default:
+		http.Error(w, "Unable to store item", http.StatusInternalServerError)
+	}
+}
+
+func seedStore(store *Store) error {
+	for _, name := range []string{"Learn Go", "Build APIs", "Deploy with Aspire"} {
+		if _, err := store.Create(name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func main() {
-	store := NewStore()
+	store := NewStore(maxStoredItems)
 
 	// Add some initial data
-	store.Create("Learn Go")
-	store.Create("Build APIs")
-	store.Create("Deploy with Aspire")
+	if err := seedStore(store); err != nil {
+		log.Fatal(err)
+	}
 
 	r := chi.NewRouter()
 	r.Use(middleware.Logger)
@@ -149,17 +239,16 @@ func main() {
 			Name string `json:"name"`
 		}
 
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			http.Error(w, "Invalid request body", http.StatusBadRequest)
+		if !decodeJSONBody(w, r, &req) {
 			return
 		}
 
-		if req.Name == "" {
-			http.Error(w, "Name is required", http.StatusBadRequest)
+		item, err := store.Create(req.Name)
+		if err != nil {
+			writeStoreError(w, err)
 			return
 		}
 
-		item := store.Create(req.Name)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 		json.NewEncoder(w).Encode(item)
@@ -177,12 +266,15 @@ func main() {
 			Completed *bool   `json:"completed"`
 		}
 
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			http.Error(w, "Invalid request body", http.StatusBadRequest)
+		if !decodeJSONBody(w, r, &req) {
 			return
 		}
 
-		item, ok := store.Update(id, req.Name, req.Completed)
+		item, ok, err := store.Update(id, req.Name, req.Completed)
+		if err != nil {
+			writeStoreError(w, err)
+			return
+		}
 		if !ok {
 			http.Error(w, "Item not found", http.StatusNotFound)
 			return
@@ -214,7 +306,15 @@ func main() {
 	}
 
 	log.Printf("Starting server on port %s", port)
-	if err := http.ListenAndServe(":"+port, r); err != nil {
+	server := &http.Server{
+		Addr:              ":" + port,
+		Handler:           r,
+		ReadTimeout:       5 * time.Second,
+		ReadHeaderTimeout: 2 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+	if err := server.ListenAndServe(); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/samples/golang-api/api/main.go
+++ b/samples/golang-api/api/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"strconv"
@@ -20,6 +21,7 @@ const (
 	maxJSONRequestBodyBytes = 1 << 20
 	maxItemNameLength       = 200
 	maxStoredItems          = 1000
+	defaultBindHost         = "127.0.0.1"
 )
 
 var (
@@ -304,10 +306,15 @@ func main() {
 	if port == "" {
 		port = "8080"
 	}
+	host := os.Getenv("HOST")
+	if host == "" {
+		host = defaultBindHost
+	}
 
-	log.Printf("Starting server on port %s", port)
+	addr := net.JoinHostPort(host, port)
+	log.Printf("Starting server on %s", addr)
 	server := &http.Server{
-		Addr:              ":" + port,
+		Addr:              addr,
 		Handler:           r,
 		ReadTimeout:       5 * time.Second,
 		ReadHeaderTimeout: 2 * time.Second,


### PR DESCRIPTION
## Summary
- Add JSON request body size limiting, item name/count validation, bounded HTTP server timeouts, and loopback-only local binding for `samples/golang-api`.
- Pin the Go API runtime image to Alpine 3.21, run the container as a non-root user, and set the container bind host to `0.0.0.0` so publish/container ingress still works.
- Document sample security limitations and link relevant Go, Docker, and OWASP guidance.

## Validation
- `go fmt ./...`, `go test ./...`, and `go build ./...` using portable Go 1.23.12 because local `go`/`gofmt` are not installed on PATH.
- `docker build --quiet --tag golang-api-bind-check samples\golang-api\api`.

## Aspire verification
- Command: `aspire run` from `samples\golang-api` with portable Go 1.23.12 on PATH.
- Result: AppHost started; dashboard available at `https://localhost:52225/login?t=8ab3aa69913b73430e08b7545acda3fb`.
- Resource status: `api` executable running from `go run main.go`; `api-go-mod-installer` completed/finished.
- Aspire resource URL: `http://localhost:55008`.
- Direct Go process listener: `main.exe` listened only on `127.0.0.1:61189`; the Aspire/DCP endpoint listened on localhost (`127.0.0.1`/`::1`) at `55008`.
- API checks: `GET /`, `GET /health`, and `GET /items` all returned HTTP 200; `/health` returned `{ "status": "healthy" }`.
- Edge screenshots saved locally under the verification session artifacts: `C:\Users\dedward\.copilot\workspaces\f81cff41-43a0-465d-8d45-680462a930cf\artifacts\golang-api-loopback-root-edge.png` and `C:\Users\dedward\.copilot\workspaces\f81cff41-43a0-465d-8d45-680462a930cf\artifacts\golang-api-loopback-aspire-resources-edge.png`.