### PR TITLE
Harden the polyglot task queue sample

### DIFF
--- a/samples/polyglot-task-queue/README.md
+++ b/samples/polyglot-task-queue/README.md
@@ -74,6 +74,22 @@ aspire deploy   # Deploy to Docker Compose
 aspire do docker-compose-down-dc  # Teardown deployment
 ```
 
+## Security Notes
+
+This sample is intended for local demo use. RabbitMQ messages are treated as trusted internal messages, and the public HTTP endpoints are unauthenticated.
+
+The Node.js API applies simple guardrails for the demo: JSON request bodies are limited to 64 KB, task `type` must be `analyze` or `report`, task `data` is capped at 10,000 characters, and `GET /tasks` returns the latest 100 tasks by default with `?limit=` capped at 500. Production services should add explicit input schemas, authentication and authorization, rate limits, a RabbitMQ retry/dead-letter policy, and capacity limits for queues, stored results, and in-memory caches.
+
+The workers acknowledge or drop invalid and failed messages instead of requeueing indefinitely. For production, configure bounded retries and a dead-letter exchange so poison messages can be inspected without blocking queue processing.
+
+Relevant references:
+
+- [Node.js security best practices](https://nodejs.org/en/learn/getting-started/security-best-practices)
+- [Express body parser limits](https://expressjs.com/en/resources/middleware/body-parser.html)
+- [RabbitMQ consumer acknowledgements and publisher confirms](https://www.rabbitmq.com/docs/confirms)
+- [RabbitMQ dead letter exchanges](https://www.rabbitmq.com/docs/dlx)
+- [OWASP API Security Top 10](https://owasp.org/API-Security/editions/2023/en/0x11-t10/)
+
 ## Key Aspire Patterns
 
 **RabbitMQ Setup** - Message queue with management UI:

--- a/samples/polyglot-task-queue/api/index.js
+++ b/samples/polyglot-task-queue/api/index.js
@@ -15,9 +15,69 @@ const tracer = trace.getTracer('api-service');
 
 const app = express();
 const port = process.env.PORT || 3000;
+const JSON_BODY_LIMIT = '64kb';
+const MAX_TASK_DATA_LENGTH = 10_000;
+const DEFAULT_TASK_LIST_LIMIT = 100;
+const MAX_TASK_LIST_LIMIT = 500;
+const SUPPORTED_TASK_TYPES = new Set(['analyze', 'report']);
 
-app.use(express.json());
+app.use(express.json({ limit: JSON_BODY_LIMIT }));
+app.use((error, req, res, next) => {
+    if (error.type === 'entity.too.large') {
+        return res.status(413).json({ error: `Request body must be ${JSON_BODY_LIMIT} or smaller` });
+    }
+
+    if (error.type === 'entity.parse.failed') {
+        return res.status(400).json({ error: 'Request body must be valid JSON' });
+    }
+
+    return next(error);
+});
 app.use(express.static(join(__dirname, 'public')));
+
+function validateTaskRequest(body) {
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+        return 'Request body must be a JSON object';
+    }
+
+    const { type, data } = body;
+
+    if (typeof type !== 'string' || type.trim().length === 0) {
+        return 'type is required';
+    }
+
+    if (!SUPPORTED_TASK_TYPES.has(type)) {
+        return `type must be one of: ${Array.from(SUPPORTED_TASK_TYPES).join(', ')}`;
+    }
+
+    if (typeof data !== 'string' || data.length === 0) {
+        return 'data is required';
+    }
+
+    if (data.length > MAX_TASK_DATA_LENGTH) {
+        return `data must be ${MAX_TASK_DATA_LENGTH} characters or fewer`;
+    }
+
+    return null;
+}
+
+function parseTaskListLimit(value) {
+    if (value === undefined) {
+        return { limit: DEFAULT_TASK_LIST_LIMIT };
+    }
+
+    const rawLimit = Array.isArray(value) ? value[0] : value;
+    if (typeof rawLimit !== 'string' || !/^\d+$/.test(rawLimit)) {
+        return { error: `limit must be a positive integer up to ${MAX_TASK_LIST_LIMIT}` };
+    }
+
+    const parsedLimit = Number.parseInt(rawLimit, 10);
+    if (parsedLimit < 1) {
+        return { error: `limit must be a positive integer up to ${MAX_TASK_LIST_LIMIT}` };
+    }
+
+    return { limit: Math.min(parsedLimit, MAX_TASK_LIST_LIMIT) };
+}
 
 // ============================================================================
 // STATE MANAGEMENT
@@ -173,9 +233,10 @@ async function consumeTaskStatus() {
                             }
 
                             // Handle error status
-                            if (statusUpdate.status === 'error' && statusUpdate.error) {
-                                task.error = statusUpdate.error;
-                                span.setAttribute('task.error', statusUpdate.error);
+                            const statusError = statusUpdate.error || statusUpdate.additionalData?.error;
+                            if (statusUpdate.status === 'error' && statusError) {
+                                task.error = statusError;
+                                span.setAttribute('task.error', statusError);
                             }
                             console.log(`🔄 [Background] Updated task in cache: ${task.id} -> ${task.status}`);
                             span.addEvent('task.updated_in_cache');
@@ -310,13 +371,13 @@ app.post('/tasks', async (req, res) => {
     // Express auto-instrumentation creates a span, we'll use it as parent
     return tracer.startActiveSpan('task.submit', async (span) => {
         try {
-            const { type, data } = req.body;
-
-            if (!type || !data) {
-                span.setStatus({ code: SpanStatusCode.ERROR, message: 'Missing required fields' });
-                span.end();
-                return res.status(400).json({ error: 'type and data are required' });
+            const validationError = validateTaskRequest(req.body);
+            if (validationError) {
+                span.setStatus({ code: SpanStatusCode.ERROR, message: validationError });
+                return res.status(400).json({ error: validationError });
             }
+
+            const { type, data } = req.body;
 
             const taskId = `task-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
             const createdAt = new Date().toISOString();
@@ -376,9 +437,17 @@ app.post('/tasks', async (req, res) => {
 
 // Get all tasks - reads ONLY from cache (Map), never queries RabbitMQ
 app.get('/tasks', (req, res) => {
+    const { limit, error } = parseTaskListLimit(req.query.limit);
+    if (error) {
+        return res.status(400).json({ error });
+    }
+
     const allTasks = Array.from(tasks.values()).sort((a, b) =>
         new Date(b.createdAt) - new Date(a.createdAt)
-    );
+    ).slice(0, limit);
+
+    res.set('X-Total-Count', String(tasks.size));
+    res.set('X-Result-Limit', String(limit));
     res.json(allTasks);
 });
 

--- a/samples/polyglot-task-queue/worker-csharp/Program.cs
+++ b/samples/polyglot-task-queue/worker-csharp/Program.cs
@@ -27,6 +27,8 @@ class ReportWorker(IConnection connection, ILogger<ReportWorker> logger) : Backg
     private const string ResultsQueue = "results";
     private const string TaskStatusQueue = "task_status";
     private const string WorkerName = "csharp-worker";
+    private const int MaxTaskDataLength = 10_000;
+    private static readonly HashSet<string> SupportedTaskTypes = new(StringComparer.Ordinal) { "analyze", "report" };
 
     // ActivitySource for distributed tracing
     private static readonly ActivitySource ActivitySource = new("TaskQueue.Worker.CSharp", "1.0.0");
@@ -83,7 +85,7 @@ class ReportWorker(IConnection connection, ILogger<ReportWorker> logger) : Backg
         {
             logger.LogError(ex, "[{Time}] Error publishing status for task {TaskId}", DateTime.Now, taskId);
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
-            activity?.RecordException(ex);
+            activity?.AddException(ex);
         }
     }
 
@@ -128,6 +130,8 @@ class ReportWorker(IConnection connection, ILogger<ReportWorker> logger) : Backg
         var consumer = new AsyncEventingBasicConsumer(channel);
         consumer.ReceivedAsync += async (model, ea) =>
         {
+            TaskMessage? task = null;
+
             // Extract trace context from message headers
             var parentContext = Propagator.Extract(default, ea.BasicProperties.Headers, (headers, key) =>
             {
@@ -154,7 +158,7 @@ class ReportWorker(IConnection connection, ILogger<ReportWorker> logger) : Backg
                 var messageBody = Encoding.UTF8.GetString(ea.Body.Span);
                 logger.LogInformation("[{Time}] Received message: {Message}", DateTime.Now, messageBody);
 
-                var task = JsonSerializer.Deserialize<TaskMessage>(messageBody, JsonOptions);
+                task = JsonSerializer.Deserialize<TaskMessage>(messageBody, JsonOptions);
 
                 if (task is null)
                 {
@@ -164,23 +168,42 @@ class ReportWorker(IConnection connection, ILogger<ReportWorker> logger) : Backg
                     return;
                 }
 
-                activity?.SetTag("task.id", task.TaskId);
-                activity?.SetTag("task.type", task.Type);
-                activity?.SetTag("messaging.message.id", task.TaskId);
+                var validationError = ValidateTaskMessage(task);
+                if (validationError is not null)
+                {
+                    logger.LogWarning("[{Time}] Dropping invalid task message: {ValidationError}", DateTime.Now, validationError);
+
+                    if (!string.IsNullOrWhiteSpace(task.TaskId))
+                    {
+                        await PublishTaskStatusAsync(channel, task.TaskId, "error",
+                            new { error = validationError }, stoppingToken);
+                    }
+
+                    await channel.BasicAckAsync(ea.DeliveryTag, false, stoppingToken);
+                    activity?.SetStatus(ActivityStatusCode.Error, validationError);
+                    return;
+                }
+
+                var taskId = task.TaskId!;
+                var taskType = task.Type!;
+
+                activity?.SetTag("task.id", taskId);
+                activity?.SetTag("task.type", taskType);
+                activity?.SetTag("messaging.message.id", taskId);
 
                 logger.LogInformation("[{Time}] Processing task {TaskId} (type: {Type})",
-                    DateTime.Now, task.TaskId, task.Type);
+                    DateTime.Now, taskId, taskType);
 
                 // Publish processing status
-                await PublishTaskStatusAsync(channel, task.TaskId!, "processing", cancellationToken: stoppingToken);
+                await PublishTaskStatusAsync(channel, taskId, "processing", cancellationToken: stoppingToken);
 
                 // Only process 'report' tasks
-                if (task.Type != "report")
+                if (taskType != "report")
                 {
                     logger.LogInformation("[{Time}] Skipping task {TaskId} - not a report task",
-                        DateTime.Now, task.TaskId);
+                        DateTime.Now, taskId);
 
-                    await PublishTaskStatusAsync(channel, task.TaskId!, "skipped",
+                    await PublishTaskStatusAsync(channel, taskId, "skipped",
                         new { reason = "not a report task" }, stoppingToken);
 
                     await channel.BasicAckAsync(ea.DeliveryTag, false, stoppingToken);
@@ -192,7 +215,7 @@ class ReportWorker(IConnection connection, ILogger<ReportWorker> logger) : Backg
                 // Process the task with a child activity
                 using (var processActivity = ActivitySource.StartActivity("task.process_report"))
                 {
-                    processActivity?.SetTag("task.id", task.TaskId);
+                    processActivity?.SetTag("task.id", taskId);
                     var result = await ProcessReportTask(task);
                     processActivity?.SetStatus(ActivityStatusCode.Ok);
 
@@ -202,11 +225,11 @@ class ReportWorker(IConnection connection, ILogger<ReportWorker> logger) : Backg
                         publishActivity?.SetTag("messaging.system", "rabbitmq");
                         publishActivity?.SetTag("messaging.destination.name", ResultsQueue);
                         publishActivity?.SetTag("messaging.operation", "publish");
-                        publishActivity?.SetTag("task.id", task.TaskId);
+                        publishActivity?.SetTag("task.id", taskId);
 
                         var resultMessage = new ResultMessage
                         {
-                            TaskId = task.TaskId,
+                            TaskId = taskId,
                             Worker = WorkerName,
                             Result = result,
                             CompletedAt = DateTime.Now
@@ -236,7 +259,7 @@ class ReportWorker(IConnection connection, ILogger<ReportWorker> logger) : Backg
                     }
                 }
 
-                logger.LogInformation("[{Time}] Completed task {TaskId}", DateTime.Now, task.TaskId);
+                logger.LogInformation("[{Time}] Completed task {TaskId}", DateTime.Now, taskId);
                 activity?.AddEvent(new ActivityEvent("task.completed"));
                 activity?.SetStatus(ActivityStatusCode.Ok);
 
@@ -245,24 +268,18 @@ class ReportWorker(IConnection connection, ILogger<ReportWorker> logger) : Backg
             catch (Exception ex)
             {
                 logger.LogError(ex, "[{Time}] Error processing message", DateTime.Now);
-                
-                // Try to publish error status if we have task info
-                try
+
+                if (!string.IsNullOrWhiteSpace(task?.TaskId))
                 {
-                    var messageBody = Encoding.UTF8.GetString(ea.Body.Span);
-                    var task = JsonSerializer.Deserialize<TaskMessage>(messageBody, JsonOptions);
-                    if (task?.TaskId != null)
-                    {
-                        await PublishTaskStatusAsync(channel, task.TaskId, "error", 
-                            new { error = ex.Message }, stoppingToken);
-                    }
+                    await PublishTaskStatusAsync(channel, task.TaskId, "error",
+                        new { error = ex.Message }, stoppingToken);
                 }
-                catch
-                {
-                    // Ignore errors in error handling
-                }
-                
-                await channel.BasicNackAsync(ea.DeliveryTag, false, true, stoppingToken);
+
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                activity?.AddException(ex);
+
+                logger.LogWarning("[{Time}] Dropping failed task message to avoid an infinite requeue loop", DateTime.Now);
+                await channel.BasicNackAsync(ea.DeliveryTag, false, false, stoppingToken);
             }
         };
 
@@ -276,6 +293,36 @@ class ReportWorker(IConnection connection, ILogger<ReportWorker> logger) : Backg
 
         // Keep the worker running
         await Task.Delay(Timeout.Infinite, stoppingToken);
+    }
+
+    private static string? ValidateTaskMessage(TaskMessage task)
+    {
+        if (string.IsNullOrWhiteSpace(task.TaskId))
+        {
+            return "taskId is required";
+        }
+
+        if (string.IsNullOrWhiteSpace(task.Type))
+        {
+            return "type is required";
+        }
+
+        if (!SupportedTaskTypes.Contains(task.Type))
+        {
+            return $"unsupported task type '{task.Type}'";
+        }
+
+        if (string.IsNullOrEmpty(task.Data))
+        {
+            return "data is required";
+        }
+
+        if (task.Data.Length > MaxTaskDataLength)
+        {
+            return $"data must be {MaxTaskDataLength} characters or fewer";
+        }
+
+        return null;
     }
 
     private async Task<object> ProcessReportTask(TaskMessage task)

--- a/samples/polyglot-task-queue/worker-csharp/worker-csharp.csproj
+++ b/samples/polyglot-task-queue/worker-csharp/worker-csharp.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <PackageReference Include="Aspire.RabbitMQ.Client" Version="13.3.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
-    <PackageReference Include="System.Text.Json" Version="10.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/polyglot-task-queue/worker-python/main.py
+++ b/samples/polyglot-task-queue/worker-python/main.py
@@ -39,6 +39,33 @@ TASKS_QUEUE = 'tasks'
 RESULTS_QUEUE = 'results'
 TASK_STATUS_QUEUE = 'task_status'
 WORKER_NAME = 'python-worker'
+MAX_TASK_DATA_LENGTH = 10_000
+SUPPORTED_TASK_TYPES = {'analyze', 'report'}
+
+def validate_task(task) -> str | None:
+    """Validate the internal task message before processing."""
+    if not isinstance(task, dict):
+        return 'task message must be a JSON object'
+
+    task_id = task.get('taskId')
+    if not isinstance(task_id, str) or not task_id.strip():
+        return 'taskId is required'
+
+    task_type = task.get('type')
+    if not isinstance(task_type, str) or not task_type.strip():
+        return 'type is required'
+
+    if task_type not in SUPPORTED_TASK_TYPES:
+        return f"unsupported task type '{task_type}'"
+
+    data = task.get('data')
+    if not isinstance(data, str) or not data:
+        return 'data is required'
+
+    if len(data) > MAX_TASK_DATA_LENGTH:
+        return f'data must be {MAX_TASK_DATA_LENGTH} characters or fewer'
+
+    return None
 
 async def publish_task_status(channel, task_id, status, **additional_data):
     """Publish task status update to RabbitMQ with trace context."""
@@ -163,8 +190,19 @@ async def on_message(message: AbstractIncomingMessage, channel):
                 span.set_attribute('messaging.operation', 'process')
 
                 task = json.loads(message.body.decode())
-                task_id = task.get('taskId')
-                task_type = task.get('type')
+                validation_error = validate_task(task)
+                task_id = task.get('taskId') if isinstance(task, dict) else None
+
+                if validation_error:
+                    print(f"[{datetime.now().isoformat()}] Dropping invalid task message: {validation_error}", file=sys.stderr)
+                    if isinstance(task_id, str) and task_id.strip():
+                        await publish_task_status(channel, task_id, 'error', error=validation_error)
+                    span.set_status(Status(StatusCode.ERROR, validation_error))
+                    span.add_event('task.invalid', {'reason': validation_error})
+                    return
+
+                task_id = task['taskId']
+                task_type = task['type']
 
                 span.set_attribute('task.id', task_id)
                 span.set_attribute('task.type', task_type)


### PR DESCRIPTION
## Summary
- Add explicit Node API body/list limits plus task type and data validation for `samples/polyglot-task-queue`
- Add worker guardrails for invalid messages and stop the C# worker from requeueing failed messages indefinitely
- Add README security notes and links for Node.js, Express body limits, RabbitMQ acks/DLX, and OWASP API Security Top 10

## Validation
- `node --check .\samples\polyglot-task-queue\api\index.js`
- `python -m py_compile .\samples\polyglot-task-queue\worker-python\main.py`
- `dotnet build .\samples\polyglot-task-queue\worker-csharp\worker-csharp.csproj --no-restore --nologo`
- `git --no-pager diff --check`

## Aspire verification
- Command: from `samples\polyglot-task-queue`, `aspire run --detach --isolated --format Json --non-interactive --nologo` with the Python `uv` scripts directory on `PATH`.
- Result: AppHost started successfully; `aspire wait` reported `messaging`, `api`, and `frontend` healthy, and `worker-csharp` and `worker-python` running.
- Resource URLs: frontend `http://localhost:59684/`, API `http://localhost:59683`, RabbitMQ Management UI `http://localhost:59686`.
- API smoke: `/health` returned healthy/connected; `/tasks` returned `X-Result-Limit: 100`; valid task submission/processing was exercised.
- Edge screenshots saved locally: `C:\Users\dedward\.copilot\workspaces\61fb1203-12d3-4ba6-8a46-808b924b6a3e\artifacts\polyglot-task-queue-frontend-edge.png`, `C:\Users\dedward\.copilot\workspaces\61fb1203-12d3-4ba6-8a46-808b924b6a3e\artifacts\polyglot-task-queue-rabbitmq-edge.png`.