### PR TITLE
Secure and document the Python OpenAI agent sample

### DIFF
--- a/samples/python-openai-agent/README.md
+++ b/samples/python-openai-agent/README.md
@@ -92,6 +92,24 @@ The Python AI agent also provides REST endpoints:
 - `GET /sessions` - List active conversation sessions
 - `DELETE /sessions/{id}` - Clear a conversation session
 
+## Security Notes
+
+This sample is instructional and is not production-ready; see the repository's
+[security disclaimer](../../README.md#security-disclaimer). By default, `/chat`
+is anonymous. If you configure `AGENT_API_KEY`, `/chat`, `GET /sessions`, and
+`DELETE /sessions/{id}` require the same value in the `X-API-Key` header.
+
+The code includes basic OpenAI quota and cost controls: message length,
+session/history caps, response token caps, per-client rate limiting, and a model
+allow-list. Production deployments should add real authentication and
+authorization (see [FastAPI security](https://fastapi.tiangolo.com/tutorial/security/)),
+abuse monitoring, persistent session storage if conversations must survive
+process restarts, and prompt/content safety controls aligned with
+[OpenAI production best practices](https://developers.openai.com/api/docs/guides/production-best-practices),
+[OpenAI safety best practices](https://developers.openai.com/api/docs/guides/safety-best-practices),
+and [OWASP LLM Prompt Injection](https://genai.owasp.org/llmrisk/llm01-prompt-injection/)
+guidance.
+
 ## Example API Usage
 
 You can also interact with the AI agent programmatically via its REST API:

--- a/samples/python-openai-agent/agent/main.py
+++ b/samples/python-openai-agent/agent/main.py
@@ -50,10 +50,11 @@ ALLOWED_MODELS: frozenset[str] = frozenset({
     "gpt-4o",
 })
 
-# Optional shared-secret auth. When AGENT_API_KEY is set the /chat endpoint
-# requires callers to send the same value via the X-API-Key header. When it
-# is not set the sample stays anonymous (the other guards still apply) and a
-# loud warning is logged on startup so it's obvious in deployment logs.
+# Optional shared-secret auth. When AGENT_API_KEY is set, state-changing and
+# session-disclosing endpoints require callers to send the same value via the
+# X-API-Key header. When it is not set the sample stays anonymous (the other
+# guards still apply) and a loud warning is logged on startup so it's obvious
+# in deployment logs.
 _api_key_required: str | None = None
 _api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
 
@@ -123,11 +124,15 @@ async def initialize_openai() -> None:
     _api_key_required = os.getenv("AGENT_API_KEY") or None
     if _api_key_required is None:
         logger.warning(
-            "AGENT_API_KEY not set. The /chat endpoint is anonymous; set "
-            "AGENT_API_KEY before exposing this sample on a public network."
+            "AGENT_API_KEY not set. The /chat and /sessions endpoints are "
+            "anonymous; set AGENT_API_KEY before exposing this sample on a "
+            "public network."
         )
     else:
-        logger.info("AGENT_API_KEY configured; /chat requires the X-API-Key header.")
+        logger.info(
+            "AGENT_API_KEY configured; /chat and /sessions require the "
+            "X-API-Key header."
+        )
 
 
 @asynccontextmanager
@@ -250,7 +255,7 @@ async def chat(request: ChatRequest) -> ChatResponse:
         raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
 
 
-@app.get("/sessions")
+@app.get("/sessions", dependencies=[Depends(_require_api_key)])
 def list_sessions():
     """List all active sessions."""
     return {
@@ -259,7 +264,7 @@ def list_sessions():
     }
 
 
-@app.delete("/sessions/{session_id}")
+@app.delete("/sessions/{session_id}", dependencies=[Depends(_require_api_key)])
 def clear_session(session_id: str):
     """Clear conversation history for a session."""
     if session_id in _session_histories:


### PR DESCRIPTION
## Summary
- Require the optional `AGENT_API_KEY` dependency for `GET /sessions` and `DELETE /sessions/{session_id}` in addition to `/chat`
- Update the Python OpenAI agent README with security notes, built-in quota/cost controls, production hardening guidance, and security documentation links

## Validation
- `python -m py_compile samples\python-openai-agent\agent\main.py`
- Static AST check verified both session management routes include `Depends(_require_api_key)`

## Aspire verification
- Command: from `samples\python-openai-agent`, set safe dummy local values for `Parameters:openai-api-key` and `AGENT_API_KEY`, then ran `aspire start --non-interactive --format Json` and `aspire wait ai-agent --non-interactive --timeout 240`
- Result: `ai-agent` reached `Running` / `Healthy`; `ai-agent-installer` finished; `openai` and `openai-api-key` were `Running` / `Healthy`
- Resource URL: `https://localhost:52414`
- Endpoint checks: `GET /health` returned `200 OK`; `GET /sessions` without `X-API-Key` returned `401 Unauthorized`; `GET /sessions` with the dummy `X-API-Key` returned `200 OK`
- Edge screenshot artifact: `C:\Users\dedward\.copilot\workspaces\04b210c9-8472-47bb-9d93-610da2ff190e\artifacts\python-openai-agent-edge.png`