### PR TITLE
Fix Angular sample TypeScript version

### DIFF
--- a/samples/aspire-with-javascript/AspireJavaScript.Angular/package-lock.json
+++ b/samples/aspire-with-javascript/AspireJavaScript.Angular/package-lock.json
@@ -32,7 +32,7 @@
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.2.0",
         "run-script-os": "^1.1.6",
-        "typescript": "~6.0.3"
+        "typescript": "~5.9.3"
       },
       "engines": {
         "node": ">=20.12"
@@ -14249,9 +14249,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/samples/aspire-with-javascript/AspireJavaScript.Angular/package.json
+++ b/samples/aspire-with-javascript/AspireJavaScript.Angular/package.json
@@ -38,7 +38,7 @@
     "karma-coverage": "~2.2.1",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.2.0",
-    "typescript": "~6.0.3",
+    "typescript": "~5.9.3",
     "run-script-os": "^1.1.6"
   },
   "overrides": {


### PR DESCRIPTION
## Summary
- Downgrade the Angular sample TypeScript dev dependency to `~5.9.3`
- Refresh the Angular sample lockfile so `@angular-devkit/build-angular` peer dependency resolution succeeds

## Validation
- `npm ci --no-audit --no-fund`
- `npm run build`