### PR TITLE
Use lockfile installs in JavaScript AppHost

### DIFF
--- a/samples/aspire-with-javascript/AspireJavaScript.AppHost/AppHost.cs
+++ b/samples/aspire-with-javascript/AspireJavaScript.AppHost/AppHost.cs
@@ -4,6 +4,7 @@ var weatherApi = builder.AddProject<Projects.AspireJavaScript_MinimalApi>("weath
     .WithExternalHttpEndpoints();
 
 builder.AddJavaScriptApp("angular", "../AspireJavaScript.Angular", runScriptName: "start")
+    .WithNpm(installCommand: "ci")
     .WithReference(weatherApi)
     .WaitFor(weatherApi)
     .WithHttpEndpoint(env: "PORT")
@@ -11,6 +12,7 @@ builder.AddJavaScriptApp("angular", "../AspireJavaScript.Angular", runScriptName
     .PublishAsDockerFile();
 
 builder.AddJavaScriptApp("react", "../AspireJavaScript.React", runScriptName: "start")
+    .WithNpm(installCommand: "ci")
     .WithReference(weatherApi)
     .WaitFor(weatherApi)
     .WithEnvironment("BROWSER", "none") // Disable opening browser on npm start
@@ -28,6 +30,7 @@ builder.AddJavaScriptApp("vue", "../AspireJavaScript.Vue")
     .PublishAsDockerFile();
 
 var reactVite = builder.AddViteApp("reactvite", "../AspireJavaScript.Vite")
+    .WithNpm(installCommand: "ci")
     .WithReference(weatherApi)
     .WithEnvironment("BROWSER", "none");
 


### PR DESCRIPTION
## Summary
- Switch the Aspire JavaScript sample AppHost front-end resources to `npm ci` so test startup honors committed lockfiles.
- Prevent Angular dependency resolution from drifting to incompatible TypeScript versions during CI.

## Validation
- `dotnet build .\samples\aspire-with-javascript\AspireJavaScript.slnx --nologo`
- `npm ci --no-audit --no-fund` in Angular, React, and Vite front-end folders

Note: I also identified that adding a `merge_group` trigger would further tighten pre-merge validation, but the available token cannot push workflow edits without `workflow` scope, so this PR keeps the fix to source files only.