### PR TITLE
Fix typos in sample README summaries

### DIFF
--- a/samples/aspire-shop/README.md
+++ b/samples/aspire-shop/README.md
@@ -4,7 +4,7 @@
 
 The app consists of four .NET services:
 
-- **AspireShop.Frontend**: This is an ASP.NET Core Blazor app that displays a paginated catlog of products and allows users to add products to a shopping cart.
+- **AspireShop.Frontend**: This is an ASP.NET Core Blazor app that displays a paginated catalog of products and allows users to add products to a shopping cart.
 - **AspireShop.CatalogService**: This is an HTTP API that provides access to the catalog of products stored in a PostgreSQL database.
 - **AspireShop.CatalogDbManager**: This is an HTTP API that manages the initialization and updating of the catalog database.
 - **AspireShop.BasketService**: This is a gRPC service that provides access to the shopping cart stored in Redis.

--- a/samples/aspire-with-python/README.md
+++ b/samples/aspire-with-python/README.md
@@ -1,6 +1,6 @@
 # Integrating a FastAPI (Python) app within an Aspire application
 
-This sample demonstrates integrating a FastAPI (Python) app and a JavaSript frontend using Aspire.
+This sample demonstrates integrating a FastAPI (Python) app and a JavaScript frontend using Aspire.
 
 The sample consists of two apps:
 

--- a/samples/container-build/README.md
+++ b/samples/container-build/README.md
@@ -1,6 +1,6 @@
-# Working with container-built resources in a Aspire application
+# Working with container-built resources in an Aspire application
 
-This sample demonstrates integrating applications into a Aspire app via Dockerfiles and container-based builds. This is especially helpful to integrate applications written in languages that Aspire does not have a native integration for, or to reduce the prerequisites required to run the application.
+This sample demonstrates integrating applications into an Aspire app via Dockerfiles and container-based builds. This is especially helpful to integrate applications written in languages that Aspire does not have a native integration for, or to reduce the prerequisites required to run the application.
 
 ![Screenshot of the Aspire dashboard showing the ginapp container resource built from a Dockerfile](./images/aspire-dashboard-container-build.png)
 

--- a/samples/database-containers/README.md
+++ b/samples/database-containers/README.md
@@ -1,6 +1,6 @@
-# Working with database containers in a Aspire application
+# Working with database containers in an Aspire application
 
-This sample demonstrates working with database containers in a Aspire app, using the features of the underlying container image to modify the default database created during container startup. This is especially helpful when not using an ORM like Entity Framework Core that can run migrations on application startup (e.g., [as in the Aspire Shop sample](../AspireShop/AspireShop.CatalogDbManager)) and handle cases when the database configured in the AppHost is not yet created.
+This sample demonstrates working with database containers in an Aspire app, using the features of the underlying container image to modify the default database created during container startup. This is especially helpful when not using an ORM like Entity Framework Core that can run migrations on application startup (e.g., [as in the Aspire Shop sample](../AspireShop/AspireShop.CatalogDbManager)) and handle cases when the database configured in the AppHost is not yet created.
 
 ![Screenshot of the Swagger UI for the API service that returns data from the configured database containers](./images/db-containers-apiservice-swagger-ui.png)
 

--- a/samples/database-containers/README.md
+++ b/samples/database-containers/README.md
@@ -1,6 +1,6 @@
 # Working with database containers in an Aspire application
 
-This sample demonstrates working with database containers in an Aspire app, using the features of the underlying container image to modify the default database created during container startup. This is especially helpful when not using an ORM like Entity Framework Core that can run migrations on application startup (e.g., [as in the Aspire Shop sample](../AspireShop/AspireShop.CatalogDbManager)) and handle cases when the database configured in the AppHost is not yet created.
+This sample demonstrates working with database containers in an Aspire app, using the features of the underlying container image to modify the default database created during container startup. This is especially helpful when not using an ORM like Entity Framework Core that can run migrations on application startup (e.g., [as in the Aspire Shop sample](../aspire-shop/AspireShop.CatalogDbManager)) and handle cases when the database configured in the AppHost is not yet created.
 
 ![Screenshot of the Swagger UI for the API service that returns data from the configured database containers](./images/db-containers-apiservice-swagger-ui.png)
 


### PR DESCRIPTION
Cleans up a few small typos in sample README intros that now surface on the new sample detail pages at aspire.dev (microsoft/aspire.dev#1089).

| Sample | Was | Now |
| --- | --- | --- |
| `aspire-shop` | `catlog` | `catalog` |
| `aspire-with-python` | `JavaSript` | `JavaScript` |
| `container-build` | `a Aspire application` / `a Aspire app` | `an Aspire application` / `an Aspire app` |
| `database-containers` | `a Aspire application` / `a Aspire app` | `an Aspire application` / `an Aspire app` |

README copy only, no code or sample-behavior changes.