### PR TITLE
Update samples for Aspire 13.3 APIs

### DIFF
--- a/samples/Metrics/MetricsApp.AppHost/MetricsApp.AppHost.csproj
+++ b/samples/Metrics/MetricsApp.AppHost/MetricsApp.AppHost.csproj
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
     <ProjectReference Include="..\MetricsApp\MetricsApp.csproj" />
   </ItemGroup>

--- a/samples/aspire-shop/AspireShop.AppHost/AspireShop.AppHost.csproj
+++ b/samples/aspire-shop/AspireShop.AppHost/AspireShop.AppHost.csproj
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.0" />
     <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.4.0" />
     <PackageReference Include="Aspire.Hosting.Redis" Version="13.4.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />

--- a/samples/aspire-with-azure-functions/Directory.Packages.props
+++ b/samples/aspire-with-azure-functions/Directory.Packages.props
@@ -3,7 +3,6 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.4.0" />
     <PackageVersion Include="Aspire.Hosting.Azure" Version="13.4.0" />
     <!-- Aspire Hosting -->
     <PackageVersion Include="Aspire.Hosting.Azure.AppContainers" Version="13.4.0" />

--- a/samples/aspire-with-azure-functions/ImageGallery.AppHost/AppHost.cs
+++ b/samples/aspire-with-azure-functions/ImageGallery.AppHost/AppHost.cs
@@ -2,7 +2,7 @@
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-builder.AddAzureContainerAppEnvironment("env");
+var env = builder.AddAzureContainerAppEnvironment("env");
 
 var storage = builder.AddAzureStorage("storage").RunAsEmulator()
     .ConfigureInfrastructure((infrastructure) =>
@@ -24,7 +24,8 @@ var storage = builder.AddAzureStorage("storage").RunAsEmulator()
 var blobs = storage.AddBlobs("blobs");
 var queues = storage.AddQueues("queues");
 
-var functions = builder.AddAzureFunctionsProject<Projects.ImageGallery_Functions>("functions")
+var functions = builder.AddAzureFunctionsProject("functions", "../ImageGallery.Functions/ImageGallery.Functions.csproj")
+                       .WithComputeEnvironment(env)
                        .WithReference(queues)
                        .WithReference(blobs)
                        .WaitFor(storage)
@@ -37,6 +38,7 @@ var functions = builder.AddAzureFunctionsProject<Projects.ImageGallery_Functions
                        .WithUrlForEndpoint("http", u => u.DisplayText = "Functions App");
 
 builder.AddProject<Projects.ImageGallery_FrontEnd>("frontend")
+       .WithComputeEnvironment(env)
        .WithReference(queues)
        .WithReference(blobs)
        .WaitFor(functions)

--- a/samples/aspire-with-azure-functions/ImageGallery.AppHost/ImageGallery.AppHost.csproj
+++ b/samples/aspire-with-azure-functions/ImageGallery.AppHost/ImageGallery.AppHost.csproj
@@ -15,7 +15,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" />
     <PackageReference Include="Aspire.Hosting.Azure" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <ProjectReference Include="..\ImageGallery.FrontEnd\ImageGallery.FrontEnd.csproj" />

--- a/samples/aspire-with-javascript/AspireJavaScript.AppHost/AppHost.cs
+++ b/samples/aspire-with-javascript/AspireJavaScript.AppHost/AppHost.cs
@@ -1,4 +1,7 @@
-﻿var builder = DistributedApplication.CreateBuilder(args);
+﻿#pragma warning disable ASPIREBROWSERLOGS001
+#pragma warning disable ASPIREJAVASCRIPT001
+
+var builder = DistributedApplication.CreateBuilder(args);
 
 var weatherApi = builder.AddProject<Projects.AspireJavaScript_MinimalApi>("weatherapi")
     .WithExternalHttpEndpoints();
@@ -9,7 +12,8 @@ builder.AddJavaScriptApp("angular", "../AspireJavaScript.Angular", runScriptName
     .WaitFor(weatherApi)
     .WithHttpEndpoint(env: "PORT")
     .WithExternalHttpEndpoints()
-    .PublishAsDockerFile();
+    .WithBrowserLogs()
+    .PublishAsStaticWebsite("/api", weatherApi, options => options.OutputPath = "dist/weather/browser");
 
 builder.AddJavaScriptApp("react", "../AspireJavaScript.React", runScriptName: "start")
     .WithNpm(installCommand: "ci")
@@ -18,7 +22,8 @@ builder.AddJavaScriptApp("react", "../AspireJavaScript.React", runScriptName: "s
     .WithEnvironment("BROWSER", "none") // Disable opening browser on npm start
     .WithHttpEndpoint(env: "PORT")
     .WithExternalHttpEndpoints()
-    .PublishAsDockerFile();
+    .WithBrowserLogs()
+    .PublishAsStaticWebsite("/api", weatherApi);
 
 builder.AddJavaScriptApp("vue", "../AspireJavaScript.Vue")
     .WithRunScript("start")
@@ -27,14 +32,14 @@ builder.AddJavaScriptApp("vue", "../AspireJavaScript.Vue")
     .WaitFor(weatherApi)
     .WithHttpEndpoint(env: "PORT")
     .WithExternalHttpEndpoints()
-    .PublishAsDockerFile();
+    .WithBrowserLogs()
+    .PublishAsStaticWebsite("/api", weatherApi);
 
-var reactVite = builder.AddViteApp("reactvite", "../AspireJavaScript.Vite")
+builder.AddViteApp("reactvite", "../AspireJavaScript.Vite")
     .WithNpm(installCommand: "ci")
     .WithReference(weatherApi)
-    .WithEnvironment("BROWSER", "none");
-
-// Bundle the output of the Vite app into the wwwroot of the weather API
-weatherApi.PublishWithContainerFiles(reactVite, "./wwwroot");
+    .WithEnvironment("BROWSER", "none")
+    .WithBrowserLogs()
+    .PublishAsStaticWebsite("/api", weatherApi);
 
 builder.Build().Run();

--- a/samples/aspire-with-javascript/AspireJavaScript.AppHost/AspireJavaScript.AppHost.csproj
+++ b/samples/aspire-with-javascript/AspireJavaScript.AppHost/AspireJavaScript.AppHost.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
     <ProjectReference Include="..\AspireJavaScript.MinimalApi\AspireJavaScript.MinimalApi.csproj" />
+    <PackageReference Include="Aspire.Hosting.Browsers" Version="13.4.0-preview.1.26281.18" />
     <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.4.0" />
   </ItemGroup>
 

--- a/samples/aspire-with-node/AspireWithNode.AppHost/AppHost.cs
+++ b/samples/aspire-with-node/AspireWithNode.AppHost/AppHost.cs
@@ -1,4 +1,6 @@
-﻿var builder = DistributedApplication.CreateBuilder(args);
+﻿#pragma warning disable ASPIREBROWSERLOGS001
+
+var builder = DistributedApplication.CreateBuilder(args);
 
 var cache = builder.AddRedis("cache")
     .WithRedisInsight();
@@ -12,6 +14,7 @@ builder.AddNodeApp("frontend", "../NodeFrontend", "./app.js")
     .WithHttpEndpoint(port: 5223, env: "PORT")
     .WithExternalHttpEndpoints()
     .WithHttpHealthCheck("/health")
+    .WithBrowserLogs()
     .WithReference(weatherapi).WaitFor(weatherapi)
     .WithReference(cache).WaitFor(cache);
 

--- a/samples/aspire-with-node/AspireWithNode.AppHost/AspireWithNode.AppHost.csproj
+++ b/samples/aspire-with-node/AspireWithNode.AppHost/AspireWithNode.AppHost.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
     <ProjectReference Include="..\AspireWithNode.AspNetCoreApi\AspireWithNode.AspNetCoreApi.csproj" />
+    <PackageReference Include="Aspire.Hosting.Browsers" Version="13.4.0-preview.1.26281.18" />
     <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.4.0" />
     <PackageReference Include="Aspire.Hosting.Redis" Version="13.4.0" />
   </ItemGroup>

--- a/samples/aspire-with-python/apphost.cs
+++ b/samples/aspire-with-python/apphost.cs
@@ -1,5 +1,9 @@
+#pragma warning disable ASPIREBROWSERLOGS001
+#pragma warning disable ASPIREJAVASCRIPT001
+
 #:sdk Aspire.AppHost.Sdk@13.4.0
 #:package Aspire.Hosting.JavaScript@13.4.0
+#:package Aspire.Hosting.Browsers@13.4.0-preview.1.26281.18
 #:package Aspire.Hosting.Python@13.4.0
 #:package Aspire.Hosting.Redis@13.4.0
 
@@ -14,10 +18,10 @@ var app = builder.AddUvicornApp("app", "./app", "main:app")
     .WaitFor(cache)
     .WithHttpHealthCheck("/health");
 
-var frontend = builder.AddViteApp("frontend", "./frontend")
+builder.AddViteApp("frontend", "./frontend")
     .WithReference(app)
-    .WaitFor(app);
-
-app.PublishWithContainerFiles(frontend, "./static");
+    .WaitFor(app)
+    .WithBrowserLogs()
+    .PublishAsStaticWebsite("/api", app);
 
 builder.Build().Run();

--- a/samples/client-apps-integration/ClientAppsIntegration.AppHost/ClientAppsIntegration.AppHost.csproj
+++ b/samples/client-apps-integration/ClientAppsIntegration.AppHost/ClientAppsIntegration.AppHost.csproj
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
     <ProjectReference Include="..\ClientAppsIntegration.ApiService\ClientAppsIntegration.ApiService.csproj" />
     <ProjectReference Include="..\ClientAppsIntegration.WinForms\ClientAppsIntegration.WinForms.csproj" />

--- a/samples/custom-resources/CustomResources.AppHost/AppHost.cs
+++ b/samples/custom-resources/CustomResources.AppHost/AppHost.cs
@@ -1,9 +1,31 @@
 using CustomResources.AppHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
 builder.AddTalkingClock("talking-clock");
 
 builder.AddTestResource("test");
+
+builder.OnBeforeStart(static (@event, cancellationToken) =>
+{
+    var logger = @event.Services.GetRequiredService<ILoggerFactory>()
+        .CreateLogger("CustomResources.AppHost");
+
+    logger.LogInformation("Starting custom resources sample with {ResourceCount} resources.", @event.Model.Resources.Count);
+
+    return Task.CompletedTask;
+});
+
+builder.Eventing.Subscribe<AfterResourcesCreatedEvent>(static (@event, cancellationToken) =>
+{
+    var logger = @event.Services.GetRequiredService<ILoggerFactory>()
+        .CreateLogger("CustomResources.AppHost");
+
+    logger.LogInformation("Custom resources sample created {ResourceCount} resources.", @event.Model.Resources.Count);
+
+    return Task.CompletedTask;
+});
 
 builder.Build().Run();

--- a/samples/custom-resources/CustomResources.AppHost/CustomResources.AppHost.csproj
+++ b/samples/custom-resources/CustomResources.AppHost/CustomResources.AppHost.csproj
@@ -8,7 +8,6 @@
     <UserSecretsId>00d08ee4-b2e0-4d12-827c-d131fda1c6f6</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
   </ItemGroup>
 

--- a/samples/custom-resources/CustomResources.AppHost/TestResource.cs
+++ b/samples/custom-resources/CustomResources.AppHost/TestResource.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -23,6 +24,24 @@ static class TestResourceExtensions
                     new(CustomResourceKnownProperties.Source, "Custom")
                 ]
             })
+            .WithCommand(
+                name: "inspect",
+                displayName: "Inspect resource",
+                executeCommand: context =>
+                {
+                    context.Logger.LogInformation("Inspect command executed for {ResourceName}.", context.ResourceName);
+
+                    var result = JsonSerializer.Serialize(new
+                    {
+                        resource = context.ResourceName,
+                        generatedAt = DateTimeOffset.UtcNow
+                    });
+
+                    return Task.FromResult(CommandResults.Success(
+                        message: "Resource inspection generated.",
+                        result: result,
+                        resultFormat: CommandResultFormat.Json));
+                })
             .ExcludeFromManifest();
 
         rb.OnInitializeResource((resource, e, ct) =>

--- a/samples/database-containers/DatabaseContainers.AppHost/DatabaseContainers.AppHost.csproj
+++ b/samples/database-containers/DatabaseContainers.AppHost/DatabaseContainers.AppHost.csproj
@@ -17,7 +17,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.0" />
     <PackageReference Include="Aspire.Hosting.MySql" Version="13.4.0" />
     <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.4.0" />
     <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.4.0" />

--- a/samples/database-migrations/DatabaseMigrations.AppHost/DatabaseMigrations.AppHost.csproj
+++ b/samples/database-migrations/DatabaseMigrations.AppHost/DatabaseMigrations.AppHost.csproj
@@ -13,7 +13,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
     <ProjectReference Include="..\DatabaseMigrations.ApiService\DatabaseMigrations.ApiService.csproj" />
     <ProjectReference Include="..\DatabaseMigrations.MigrationService\DatabaseMigrations.MigrationService.csproj" />

--- a/samples/health-checks-ui/HealthChecksUI.AppHost/AppHost.cs
+++ b/samples/health-checks-ui/HealthChecksUI.AppHost/AppHost.cs
@@ -1,15 +1,18 @@
 ﻿var builder = DistributedApplication.CreateBuilder(args);
 
-builder.AddDockerComposeEnvironment("compose");
+var compose = builder.AddDockerComposeEnvironment("compose");
 
-var cache = builder.AddRedis("cache");
+var cache = builder.AddRedis("cache")
+    .WithComputeEnvironment(compose);
 
 var apiService = builder.AddProject<Projects.HealthChecksUI_ApiService>("apiservice")
+    .WithComputeEnvironment(compose)
     .WithHttpHealthCheck("/health")
     .WithHttpProbe(ProbeType.Liveness, "/alive")
     .WithFriendlyUrls(displayText: "API");
 
 var webFrontend = builder.AddProject<Projects.HealthChecksUI_Web>("webfrontend")
+    .WithComputeEnvironment(compose)
     .WithReference(cache)
     .WaitFor(cache)
     .WithReference(apiService)
@@ -20,6 +23,7 @@ var webFrontend = builder.AddProject<Projects.HealthChecksUI_Web>("webfrontend")
     .WithExternalHttpEndpoints();
 
 var healthChecksUI = builder.AddHealthChecksUI("healthchecksui")
+    .WithComputeEnvironment(compose)
     .WithReference(apiService)
     .WithReference(webFrontend)
     .WithFriendlyUrls("HealthChecksUI Dashboard", "http")

--- a/samples/health-checks-ui/HealthChecksUI.AppHost/HealthChecksUI.AppHost.csproj
+++ b/samples/health-checks-ui/HealthChecksUI.AppHost/HealthChecksUI.AppHost.csproj
@@ -14,7 +14,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.0" />
     <PackageReference Include="Aspire.Hosting.Docker" Version="13.4.0" />
     <PackageReference Include="Aspire.Hosting.Redis" Version="13.4.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />

--- a/samples/image-gallery/README.md
+++ b/samples/image-gallery/README.md
@@ -19,7 +19,8 @@ flowchart LR
 **Publish Mode:**
 ```mermaid
 flowchart LR
-    Browser --> API[C# API serving<br/>Vite build output<br/>'npm run build']
+    Browser --> Frontend[Static website serving<br/>Vite build output<br/>'npm run build']
+    Frontend -->|Proxy /api| API[C# API]
     API --> Blobs[Azure Blob Storage]
     API --> Queue[Azure Storage Queue]
     API --> SQL[Azure SQL]
@@ -54,7 +55,7 @@ flowchart LR
 - **Dual-Mode Resources**: Azurite/SQL Server containers locally, Azure services in production (`.RunAsEmulator()`, `.RunAsContainer()`)
 - **Free Tier Deployment**: Azure SQL free tier with serverless auto-pause, Container Apps scale-to-zero
 - **Managed Identity**: Password-less authentication to all Azure resources (Storage, SQL, Queues)
-- **Polyglot Stack**: Vite+React frontend embedded in C# API container, SkiaSharp for image processing
+- **Polyglot Stack**: Vite+React frontend published as a static website, SkiaSharp for image processing
 - **OpenTelemetry**: Distributed tracing across upload → queue → worker pipeline
 
 ## Running Locally
@@ -194,9 +195,9 @@ else
 }
 ```
 
-**Container Files Publishing** - Embed Vite build output in API container:
+**Static Website Publishing** - Publish the Vite app as a static website with API proxying:
 ```csharp
-api.PublishWithContainerFiles(frontend, "wwwroot");
+frontend.PublishAsStaticWebsite("/api", api);
 ```
 
 ## Performance & Cost Characteristics

--- a/samples/image-gallery/apphost.cs
+++ b/samples/image-gallery/apphost.cs
@@ -1,10 +1,13 @@
 #pragma warning disable ASPIRECSHARPAPPS001
 #pragma warning disable ASPIREAZURE002
+#pragma warning disable ASPIREBROWSERLOGS001
+#pragma warning disable ASPIREJAVASCRIPT001
 
 #:sdk Aspire.AppHost.Sdk@13.4.0
 #:package Aspire.Hosting.Azure.Storage@13.4.0
 #:package Aspire.Hosting.Azure.Sql@13.4.0
 #:package Aspire.Hosting.JavaScript@13.4.0
+#:package Aspire.Hosting.Browsers@13.4.0-preview.1.26281.18
 #:package Aspire.Hosting.Azure.AppContainers@13.4.0
 
 using Aspire.Hosting.Azure;
@@ -13,7 +16,7 @@ using Azure.Provisioning.Expressions;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-builder.AddAzureContainerAppEnvironment("env");
+var env = builder.AddAzureContainerAppEnvironment("env");
 
 // Storage: Use Azurite emulator in run mode, real Azure in publish mode
 var storage = builder.AddAzureStorage("storage")
@@ -29,6 +32,7 @@ var sql = builder.AddAzureSqlServer("sql")
 
 // API: Upload images, queue thumbnail jobs, serve metadata
 var api = builder.AddCSharpApp("api", "./api")
+    .WithComputeEnvironment(env)
     .WithHttpHealthCheck("/health")
     .WithExternalHttpEndpoints()
     .WaitFor(sql)
@@ -58,6 +62,7 @@ var api = builder.AddCSharpApp("api", "./api")
 // Worker: Container Apps Job for queue-triggered thumbnail generation
 // Event-driven: starts when messages arrive, exits within ~5 seconds when queue is empty
 var worker = builder.AddCSharpApp("worker", "./worker")
+    .WithComputeEnvironment(env)
     .WithReference(blobs)
     .WithReference(queues)
     .WithReference(sql)
@@ -99,13 +104,12 @@ else
 }
 
 // Frontend: Vite+React for upload and gallery UI
-var frontend = builder.AddViteApp("frontend", "./frontend")
+builder.AddViteApp("frontend", "./frontend")
     .WithEndpoint("http", e => e.Port = 9080)
     .WithReference(api)
-    .WithUrl("", "Image Gallery");
-
-// Publish: Embed frontend build output in API container
-api.PublishWithContainerFiles(frontend, "wwwroot");
+    .WithUrl("", "Image Gallery")
+    .WithBrowserLogs()
+    .WithComputeEnvironment(env)
+    .PublishAsStaticWebsite("/api", api);
 
 builder.Build().Run();
-

--- a/samples/node-express-redis/apphost.mts
+++ b/samples/node-express-redis/apphost.mts
@@ -3,14 +3,16 @@ import { createBuilder } from "./.aspire/modules/aspire.mjs";
 const builder = await createBuilder();
 const executionContext = await builder.executionContext();
 
-await builder.addDockerComposeEnvironment("dc");
+const dc = await builder.addDockerComposeEnvironment("dc");
 
 const redis = await builder.addRedis("redis")
-    .withRedisInsight();
+    .withRedisInsight()
+    .withComputeEnvironment(dc);
 
 const api = await builder.addNodeApp("api", "./api", "index.js")
     .withHttpEndpoint({ env: "PORT" })
     .withHttpHealthCheck({ path: "/health" })
+    .withComputeEnvironment(dc)
     .waitFor(redis)
     .withReference(redis);
 
@@ -31,7 +33,9 @@ await builder.addYarp("app")
         }
     })
     .withExternalHttpEndpoints()
+    .withBrowserLogs()
     .publishWithStaticFiles(frontend)
+    .withComputeEnvironment(dc)
     .withExplicitStart();
 
 await builder.build().run();

--- a/samples/node-express-redis/aspire.config.json
+++ b/samples/node-express-redis/aspire.config.json
@@ -16,6 +16,7 @@
     }
   },
   "packages": {
+    "Aspire.Hosting.Browsers": "13.4.0-preview.1.26281.18",
     "Aspire.Hosting.JavaScript": "13.4.0",
     "Aspire.Hosting.Redis": "13.4.0",
     "Aspire.Hosting.Yarp": "13.4.0",

--- a/samples/orleans-voting/OrleansVoting.AppHost/OrleansVoting.AppHost.csproj
+++ b/samples/orleans-voting/OrleansVoting.AppHost/OrleansVoting.AppHost.csproj
@@ -14,7 +14,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
     <ProjectReference Include="..\OrleansVoting.Service\OrleansVoting.Service.csproj" />
   </ItemGroup>

--- a/samples/polyglot-task-queue/apphost.mts
+++ b/samples/polyglot-task-queue/apphost.mts
@@ -2,10 +2,11 @@ import { ContainerLifetime, UrlDisplayLocation, createBuilder } from "./.aspire/
 
 const builder = await createBuilder();
 
-await builder.addDockerComposeEnvironment("dc");
+const dc = await builder.addDockerComposeEnvironment("dc");
 
 const rabbitmq = await builder.addRabbitMQ("messaging")
     .withManagementPlugin()
+    .withComputeEnvironment(dc)
     .withLifetime(ContainerLifetime.Persistent)
     .withUrlForEndpoint("tcp", async (url) =>
     {
@@ -19,19 +20,23 @@ const rabbitmq = await builder.addRabbitMQ("messaging")
 const api = await builder.addNodeApp("api", "./api", "index.js")
     .withHttpEndpoint({ env: "PORT" })
     .withHttpHealthCheck({ path: "/health" })
+    .withComputeEnvironment(dc)
     .waitFor(rabbitmq)
     .withReference(rabbitmq);
 
 const frontend = await builder.addViteApp("frontend", "./frontend")
     .withReference(api)
-    .withUrl("", { displayText: "Task Queue UI" });
+    .withUrl("", { displayText: "Task Queue UI" })
+    .withBrowserLogs();
 
 await builder.addPythonApp("worker-python", "./worker-python", "main.py")
     .withUv()
+    .withComputeEnvironment(dc)
     .waitFor(rabbitmq)
     .withReference(rabbitmq);
 
 await builder.addCSharpApp("worker-csharp", "./worker-csharp")
+    .withComputeEnvironment(dc)
     .waitFor(rabbitmq)
     .withReference(rabbitmq);
 

--- a/samples/polyglot-task-queue/aspire.config.json
+++ b/samples/polyglot-task-queue/aspire.config.json
@@ -16,6 +16,7 @@
     }
   },
   "packages": {
+    "Aspire.Hosting.Browsers": "13.4.0-preview.1.26281.18",
     "Aspire.Hosting.RabbitMQ": "13.4.0",
     "Aspire.Hosting.Python": "13.4.0",
     "Aspire.Hosting.JavaScript": "13.4.0",

--- a/samples/rag-document-qa-svelte/apphost.mts
+++ b/samples/rag-document-qa-svelte/apphost.mts
@@ -19,7 +19,8 @@ const api = await builder.addUvicornApp("api", "./api", "main:app")
 
 const frontend = await builder.addViteApp("frontend", "./frontend")
     .withReference(api)
-    .withUrl("", { displayText: "RAG UI" });
+    .withUrl("", { displayText: "RAG UI" })
+    .withBrowserLogs();
 
 await api.publishWithContainerFiles(frontend, "public");
 

--- a/samples/rag-document-qa-svelte/aspire.config.json
+++ b/samples/rag-document-qa-svelte/aspire.config.json
@@ -16,6 +16,7 @@
     }
   },
   "packages": {
+    "Aspire.Hosting.Browsers": "13.4.0-preview.1.26281.18",
     "Aspire.Hosting.Python": "13.4.0",
     "Aspire.Hosting.JavaScript": "13.4.0",
     "Aspire.Hosting.Qdrant": "13.4.0",

--- a/samples/vite-csharp-postgres/apphost.mts
+++ b/samples/vite-csharp-postgres/apphost.mts
@@ -2,9 +2,10 @@ import { ContainerLifetime, UrlDisplayLocation, createBuilder } from "./.aspire/
 
 const builder = await createBuilder();
 
-await builder.addDockerComposeEnvironment("dc");
+const dc = await builder.addDockerComposeEnvironment("dc");
 
 const postgres = await builder.addPostgres("postgres")
+    .withComputeEnvironment(dc)
     .withDataVolume()
     .withLifetime(ContainerLifetime.Persistent)
     .withPgAdmin({
@@ -19,6 +20,7 @@ const db = await postgres.addDatabase("db");
 const api = await builder.addCSharpApp("api", "./api")
     .withHttpHealthCheck({ path: "/health" })
     .withExternalHttpEndpoints()
+    .withComputeEnvironment(dc)
     .waitFor(db)
     .withReference(db)
     .withUrlForEndpoint("http", async (url) =>
@@ -42,7 +44,8 @@ const api = await builder.addCSharpApp("api", "./api")
 
 const frontend = await builder.addViteApp("frontend", "./frontend")
     .withReference(api)
-    .withUrl("", { displayText: "Todo UI" });
+    .withUrl("", { displayText: "Todo UI" })
+    .withBrowserLogs();
 
 await api.publishWithContainerFiles(frontend, "wwwroot");
 

--- a/samples/vite-csharp-postgres/aspire.config.json
+++ b/samples/vite-csharp-postgres/aspire.config.json
@@ -16,6 +16,7 @@
     }
   },
   "packages": {
+    "Aspire.Hosting.Browsers": "13.4.0-preview.1.26281.18",
     "Aspire.Hosting.PostgreSQL": "13.4.0",
     "Aspire.Hosting.JavaScript": "13.4.0",
     "Aspire.Hosting.Docker": "13.4.0"

--- a/samples/vite-react-fastapi/apphost.mts
+++ b/samples/vite-react-fastapi/apphost.mts
@@ -3,10 +3,11 @@ import { createBuilder } from "./.aspire/modules/aspire.mjs";
 const builder = await createBuilder();
 const executionContext = await builder.executionContext();
 
-await builder.addDockerComposeEnvironment("dc");
+const dc = await builder.addDockerComposeEnvironment("dc");
 
 const api = await builder.addUvicornApp("api", "./api", "main:app")
-    .withHttpHealthCheck({ path: "/health" });
+    .withHttpHealthCheck({ path: "/health" })
+    .withComputeEnvironment(dc);
 
 const frontend = await builder.addViteApp("frontend", "./frontend")
     .withReference(api);
@@ -27,7 +28,9 @@ await builder.addYarp("app")
     })
     .withReference(api)
     .withExternalHttpEndpoints()
+    .withBrowserLogs()
     .publishWithStaticFiles(frontend)
+    .withComputeEnvironment(dc)
     .withExplicitStart();
 
 await builder.build().run();

--- a/samples/vite-react-fastapi/aspire.config.json
+++ b/samples/vite-react-fastapi/aspire.config.json
@@ -16,6 +16,7 @@
     }
   },
   "packages": {
+    "Aspire.Hosting.Browsers": "13.4.0-preview.1.26281.18",
     "Aspire.Hosting.Python": "13.4.0",
     "Aspire.Hosting.JavaScript": "13.4.0",
     "Aspire.Hosting.Yarp": "13.4.0",

--- a/samples/vite-yarp-static/apphost.mts
+++ b/samples/vite-yarp-static/apphost.mts
@@ -3,7 +3,7 @@ import { createBuilder } from "./.aspire/modules/aspire.mjs";
 const builder = await createBuilder();
 const executionContext = await builder.executionContext();
 
-await builder.addDockerComposeEnvironment("dc");
+const dc = await builder.addDockerComposeEnvironment("dc");
 
 const frontend = await builder.addViteApp("frontend", "./frontend");
 
@@ -17,6 +17,8 @@ await builder.addYarp("app")
         }
     })
     .withExternalHttpEndpoints()
-    .publishWithStaticFiles(frontend);
+    .withBrowserLogs()
+    .publishWithStaticFiles(frontend)
+    .withComputeEnvironment(dc);
 
 await builder.build().run();

--- a/samples/vite-yarp-static/aspire.config.json
+++ b/samples/vite-yarp-static/aspire.config.json
@@ -16,6 +16,7 @@
     }
   },
   "packages": {
+    "Aspire.Hosting.Browsers": "13.4.0-preview.1.26281.18",
     "Aspire.Hosting.JavaScript": "13.4.0",
     "Aspire.Hosting.Yarp": "13.4.0",
     "Aspire.Hosting.Docker": "13.4.0"

--- a/samples/volume-mount/VolumeMount.AppHost/VolumeMount.AppHost.csproj
+++ b/samples/volume-mount/VolumeMount.AppHost/VolumeMount.AppHost.csproj
@@ -15,7 +15,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
     <ProjectReference Include="..\VolumeMount.BlazorWeb\VolumeMount.BlazorWeb.csproj" />
   </ItemGroup>

--- a/tests/SamplesIntegrationTests/Infrastructure/DistributedApplicationExtensions.cs
+++ b/tests/SamplesIntegrationTests/Infrastructure/DistributedApplicationExtensions.cs
@@ -232,6 +232,13 @@ public static partial class DistributedApplicationExtensions
             return true;
         }
 
+        // BrowserLogs resources are dashboard command resources; they do not have a
+        // service lifecycle to wait for during AppHost startup tests.
+        if (resource.GetType().FullName?.Contains("BrowserLogs", StringComparison.Ordinal) == true)
+        {
+            return true;
+        }
+
 #pragma warning disable ASPIREAZURE001 // AzureEnvironmentResource is experimental.
         if (resource is AzureEnvironmentResource)
         {


### PR DESCRIPTION
## Summary

- Add `Aspire.Hosting.Browsers`/browser-log instrumentation to existing frontend samples.
- Refresh selected JavaScript publishing patterns to use `PublishAsStaticWebsite` where it preserves sample intent.
- Bind deployable resources to declared compute environments in deployment-focused samples.
- Update the Azure Functions sample to use the non-generic `AddAzureFunctionsProject(name, projectPath)` overload.
- Refresh the custom resources sample with lifecycle event handling and structured command output.
- Remove redundant `Aspire.Hosting.AppHost` references from AppHost SDK projects.

Closes #1626

## Validation

- `aspire restore --non-interactive` for updated TypeScript AppHost samples
- `npm exec --yes tsc -- --noEmit -p tsconfig.apphost.json` for updated TypeScript AppHost samples
- Targeted `dotnet build` for changed sample solutions/AppHosts
- `dotnet build .\tests\SamplesIntegrationTests\SamplesIntegrationTests.csproj --no-restore --nologo --verbosity minimal --tl:off /m:1`

Note: `dotnet test .\tests\SamplesTests.slnx --no-build --nologo --verbosity minimal --tl:off /m:1` was attempted, but stopped after 10 minutes without progress output.