### PR TITLE
Add Go SDK to devcontainer so all samples run in Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,6 +9,7 @@
 		"ghcr.io/dotnet/aspire-devcontainer-feature/dotnetaspire:1": {},
 		"ghcr.io/devcontainers/features/node:1": {},
 		"ghcr.io/devcontainers/features/python:1": {},
+		"ghcr.io/devcontainers/features/go:1": {},
 		"ghcr.io/devcontainers/features/dotnet:2": {
 			"version": "none",
 			"aspNetCoreRuntimeVersions": "10.0"


### PR DESCRIPTION
Addresses #691.

## Context

The repo already ships a shared `.devcontainer/devcontainer.json` (added in #740) and the README documents Dev Container / Codespaces usage, so the core ask of #691 — *"ensure this repo is set up to support [GitHub Codespaces]"* — is mostly in place. The remaining gap is that one sample's host runtime is missing, so it can't actually run in a Codespace.

## The gap

The shared devcontainer covers Node, Python, .NET 10, Docker (docker-in-docker), and Azure Functions Core Tools — but **not Go**.

`samples/golang-api` uses a TypeScript AppHost that runs the Go API **directly on the host** during local development:

```ts
const api = await builder.addExecutable("api", "go", "./api", ["run", "main.go"]) ...
const goModInstaller = await builder.addExecutable("api-go-mod-installer", "go", "./api", ["mod", "tidy"]) ...
```

Without the Go SDK on the host, `aspire run` for that sample fails in Codespaces / dev containers.

> Note: the other Go usage, `samples/container-build/ginapp`, builds Go inside a Dockerfile, so it only needs Docker — not a host Go SDK. `golang-api` is the only sample that requires Go on the host.

## Change

Add the `go` dev container feature alongside the existing `node` and `python` features:

```jsonc
"ghcr.io/devcontainers/features/go:1": {},
```

This installs the latest stable Go, which satisfies `samples/golang-api/api/go.mod` (`go 1.23`). The feature is left unpinned for consistency with the other language features in the file (`node`, `python`).

With this, every sample in the repo is runnable in Codespaces.

## Validation

- Verified `samples/golang-api/apphost.mts` invokes host `go` via `addExecutable`, and `samples/golang-api/api/go.mod` requires Go 1.23.
- Confirmed no other host language runtime is missing (audited all samples; no Rust/Java; `container-build` builds Go via Docker).
- Verified `.devcontainer/devcontainer.json` is valid JSON after the edit.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>