### PR TITLE
Wait for resources to become healthy in integration tests

### DIFF
--- a/tests/SamplesIntegrationTests/Infrastructure/DistributedApplicationExtensions.cs
+++ b/tests/SamplesIntegrationTests/Infrastructure/DistributedApplicationExtensions.cs
@@ -9,6 +9,7 @@ using Aspire.Hosting.Azure;
 using Aspire.Hosting.JavaScript;
 using Aspire.Hosting.Python;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
@@ -131,16 +132,17 @@ public static partial class DistributedApplicationExtensions
     }
 
     /// <summary>
-    /// Waits for all resources in the application to reach one of the specified states.
+    /// Waits for all resources in the application to become healthy or run to completion.
     /// </summary>
     /// <remarks>
-    /// If <paramref name="targetStates"/> is null, the default states are <see cref="KnownResourceStates.Running"/> and <see cref="KnownResourceStates.Hidden"/>.
+    /// Resources with health checks must report <see cref="HealthStatus.Healthy"/>; resources without health
+    /// checks are considered healthy once running. Resources that run to completion (e.g. database migration
+    /// projects) are considered done once they reach one of the <see cref="KnownResourceStates.TerminalStates"/>.
     /// </remarks>
-    public static async Task WaitForResourcesAsync(this DistributedApplication app, IEnumerable<string>? targetStates = null, CancellationToken cancellationToken = default)
+    public static async Task WaitForResourcesAsync(this DistributedApplication app, CancellationToken cancellationToken = default)
     {
         var logger = app.Services.GetRequiredService<ILoggerFactory>().CreateLogger($"{nameof(SamplesIntegrationTests)}.{nameof(WaitForResourcesAsync)}");
 
-        targetStates ??= [KnownResourceStates.Running, ..KnownResourceStates.TerminalStates];
         var applicationModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 
         var resourceTasks = new Dictionary<string, Task<(string Name, string State)>>();
@@ -152,14 +154,12 @@ public static partial class DistributedApplicationExtensions
                 continue;
             }
 
-            resourceTasks[resource.Name] = GetResourceWaitTask(resource.Name, targetStates, cancellationToken);
+            resourceTasks[resource.Name] = GetResourceWaitTask(resource.Name, cancellationToken);
         }
 
         if (logger.IsEnabled(LogLevel.Information))
         {
-            logger.LogInformation("Waiting for resources [{Resources}] to reach one of target states [{TargetStates}].",
-                string.Join(',', resourceTasks.Keys),
-                string.Join(',', targetStates));
+            logger.LogInformation("Waiting for resources [{Resources}] to become healthy.", string.Join(',', resourceTasks.Keys));
         }
 
         while (resourceTasks.Count > 0)
@@ -199,19 +199,21 @@ public static partial class DistributedApplicationExtensions
             {
                 if (logger.IsEnabled(LogLevel.Information))
                 {
-                    logger.LogInformation("Still waiting for resources [{Resources}] to reach one of target states [{TargetStates}].",
-                        string.Join(',', remainingResources),
-                        string.Join(',', targetStates));
+                    logger.LogInformation("Still waiting for resources [{Resources}] to become healthy.", string.Join(',', remainingResources));
                 }
             }
         }
 
         logger.LogInformation("Wait for all resources completed successfully!");
 
-        async Task<(string Name, string State)> GetResourceWaitTask(string resourceName, IEnumerable<string> targetStates, CancellationToken cancellationToken)
+        async Task<(string Name, string State)> GetResourceWaitTask(string resourceName, CancellationToken cancellationToken)
         {
-            var state = await app.ResourceNotifications.WaitForResourceAsync(resourceName, targetStates, cancellationToken);
-            return (resourceName, state);
+            var resourceEvent = await app.ResourceNotifications.WaitForResourceAsync(
+                resourceName,
+                re => re.Snapshot.HealthStatus is HealthStatus.Healthy
+                    || (re.Snapshot.State?.Text is { Length: > 0 } stateText && KnownResourceStates.TerminalStates.Contains(stateText)),
+                cancellationToken);
+            return (resourceName, resourceEvent.Snapshot.State?.Text ?? "Unknown");
         }
     }
 

--- a/tests/SamplesIntegrationTests/Infrastructure/DistributedApplicationExtensions.cs
+++ b/tests/SamplesIntegrationTests/Infrastructure/DistributedApplicationExtensions.cs
@@ -159,7 +159,7 @@ public static partial class DistributedApplicationExtensions
 
         if (logger.IsEnabled(LogLevel.Information))
         {
-            logger.LogInformation("Waiting for resources [{Resources}] to become healthy.", string.Join(',', resourceTasks.Keys));
+            logger.LogInformation("Waiting for resources [{Resources}] to become healthy or run to completion.", string.Join(',', resourceTasks.Keys));
         }
 
         while (resourceTasks.Count > 0)
@@ -199,7 +199,7 @@ public static partial class DistributedApplicationExtensions
             {
                 if (logger.IsEnabled(LogLevel.Information))
                 {
-                    logger.LogInformation("Still waiting for resources [{Resources}] to become healthy.", string.Join(',', remainingResources));
+                    logger.LogInformation("Still waiting for resources [{Resources}] to become healthy or run to completion.", string.Join(',', remainingResources));
                 }
             }
         }


### PR DESCRIPTION
Fixes #705

## What

Changes the `WaitForResourcesAsync` test helper (used by `AppHostTests`) to wait for each resource to report a **healthy** health status rather than merely reaching the `Running` state. A resource being `Running` doesn't mean its health checks have passed, so the old behavior could let tests start hitting endpoints before resources were actually ready.

## How

`GetResourceWaitTask` now uses the predicate overload of `ResourceNotificationService.WaitForResourceAsync`, completing when a resource is `HealthStatus.Healthy` **or** has reached one of `KnownResourceStates.TerminalStates`:

```csharp
re => re.Snapshot.HealthStatus is HealthStatus.Healthy
    || (re.Snapshot.State?.Text is { Length: > 0 } stateText && KnownResourceStates.TerminalStates.Contains(stateText))
```

- Resources **without** health checks are still considered healthy once running (Aspire reports `Healthy` for them automatically), so resources like Redis/Postgres/Node/Python without explicit health annotations don't regress.
- **Completion-style** resources that legitimately run to completion without becoming healthy — e.g. the `migration` projects in `DatabaseMigrations.AppHost` and `VolumeMount.AppHost` (added via `AddProject(...).WaitForCompletion(...)`, which are *not* explicit-start and therefore flow through this helper) — are still accepted once they reach a terminal state such as `Finished`. This is why `WaitForResourceHealthyAsync` isn't called directly: with its default `StopOnResourceUnavailable` behavior it throws when a resource reaches `Finished` without being healthy.
- Existing failure handling is preserved: a resource reaching `FailedToStart` still throws.

The now-unused `targetStates` parameter was removed (both call sites used the default), and the XML doc and log messages were updated to reflect the health-based wait.

## Validation

- Compiled the full `SamplesIntegrationTests` source against Aspire 13.4.3 with `TreatWarningsAsErrors=true` — 0 warnings, 0 errors.
- API usage (`WaitForResourceAsync` predicate overload, `CustomResourceSnapshot.HealthStatus`, `KnownResourceStates.TerminalStates`) verified against the Aspire.Hosting assembly.