### PR TITLE
Use MigrationsAssembly(Assembly) overload in database-migrations sample

### DIFF
--- a/samples/database-migrations/DatabaseMigrations.MigrationService/Program.cs
+++ b/samples/database-migrations/DatabaseMigrations.MigrationService/Program.cs
@@ -9,7 +9,7 @@ builder.AddServiceDefaults();
 
 builder.Services.AddDbContextPool<MyDb1Context>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("db1"), sqlOptions =>
-        sqlOptions.MigrationsAssembly("DatabaseMigrations.MigrationService")
+        sqlOptions.MigrationsAssembly(typeof(ApiDbInitializer).Assembly)
     ));
 builder.EnrichSqlServerDbContext<MyDb1Context>();
 


### PR DESCRIPTION
## Summary

Addresses #1456 by switching the database-migrations sample to the typed `MigrationsAssembly(Assembly)` overload instead of passing a literal assembly-name string.

```csharp
// Before
sqlOptions.MigrationsAssembly("DatabaseMigrations.MigrationService")

// After
sqlOptions.MigrationsAssembly(typeof(ApiDbInitializer).Assembly)
```

The migrations live in the `DatabaseMigrations.MigrationService` assembly, so the assembly is resolved via `typeof(ApiDbInitializer).Assembly` (a public type already in scope from that assembly). This avoids the magic string and keeps the reference refactor-safe.

The `MigrationsAssembly(Assembly)` overload is available in EF Core 9+ ([API docs](https://learn.microsoft.com/dotnet/api/microsoft.entityframeworkcore.infrastructure.relationaldbcontextoptionsbuilder-2.migrationsassembly)), and this sample targets net10.0 / EF Core 10, so it's applicable.

## Testing

- `dotnet build` on `DatabaseMigrations.MigrationService` — succeeds with 0 warnings, 0 errors.

Fixes #1456