### PR TITLE
Serve the Azure Functions host over HTTPS in the Functions sample

### DIFF
--- a/samples/Metrics/ServiceDefaults/ServiceDefaults.csproj
+++ b/samples/Metrics/ServiceDefaults/ServiceDefaults.csproj
@@ -9,6 +9,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.7.0" />

--- a/samples/aspire-shop/AspireShop.CatalogService/AspireShop.CatalogService.csproj
+++ b/samples/aspire-shop/AspireShop.CatalogService/AspireShop.CatalogService.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.16.11" />
   </ItemGroup>
 

--- a/samples/aspire-with-azure-functions/ImageGallery.AppHost/AppHost.cs
+++ b/samples/aspire-with-azure-functions/ImageGallery.AppHost/AppHost.cs
@@ -34,7 +34,35 @@ var functions = builder.AddAzureFunctionsProject<Projects.ImageGallery_Functions
                             // Queue Data Contributor role is required to send messages to the queue
                             StorageBuiltInRole.StorageQueueDataContributor)
                        .WithHostStorage(storage)
-                       .WithUrlForEndpoint("http", u => u.DisplayText = "Functions App");
+                       .WithUrlForEndpoint("https", u => u.DisplayText = "Functions App");
+
+if (builder.ExecutionContext.IsRunMode)
+{
+    // The Functions project's launchSettings.json passes '--useHttps' to the local Azure Functions host.
+    // Azure Functions Core Tools can't auto-generate a certificate on the .NET build of the tools, so the
+    // trusted ASP.NET Core developer certificate is exported to a password-protected PFX and handed to
+    // 'func host start' via its --cert/--password options.
+    var functionsCertPassword = builder.AddResource(
+        ParameterResourceBuilderExtensions.CreateGeneratedParameter(
+            builder,
+            "functions-cert-password",
+            secret: true,
+            parameterDefault: new GenerateParameterDefault()));
+
+    // The developer certificate APIs used below to serve the Azure Functions host over HTTPS are experimental.
+#pragma warning disable ASPIRECERTIFICATES001
+    functions
+        .WithHttpsDeveloperCertificate(functionsCertPassword)
+        .WithHttpsCertificateConfiguration(context =>
+        {
+            context.Arguments.Add("--cert");
+            context.Arguments.Add(context.PfxPath);
+            context.Arguments.Add("--password");
+            context.Arguments.Add(context.Password!);
+            return Task.CompletedTask;
+        });
+#pragma warning restore ASPIRECERTIFICATES001
+}
 
 builder.AddProject<Projects.ImageGallery_FrontEnd>("frontend")
        .WithReference(queues)

--- a/samples/aspire-with-azure-functions/ImageGallery.Functions/Properties/launchSettings.json
+++ b/samples/aspire-with-azure-functions/ImageGallery.Functions/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "ImageGalleryFunctions": {
       "commandName": "Project",
-      "commandLineArgs": "--port 7221",
+      "commandLineArgs": "--port 7221 --useHttps",
       "launchBrowser": false
     }
   }

--- a/samples/aspire-with-javascript/AspireJavaScript.MinimalApi/AspireJavaScript.MinimalApi.csproj
+++ b/samples/aspire-with-javascript/AspireJavaScript.MinimalApi/AspireJavaScript.MinimalApi.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.16.11" />
   </ItemGroup>
 

--- a/samples/aspire-with-python/apphost.cs
+++ b/samples/aspire-with-python/apphost.cs
@@ -1,7 +1,7 @@
-#:sdk Aspire.AppHost.Sdk@13.4.0
-#:package Aspire.Hosting.JavaScript@13.4.0
-#:package Aspire.Hosting.Python@13.4.0
-#:package Aspire.Hosting.Redis@13.4.0
+#:sdk Aspire.AppHost.Sdk@13.4.6
+#:package Aspire.Hosting.JavaScript@13.4.6
+#:package Aspire.Hosting.Python@13.4.6
+#:package Aspire.Hosting.Redis@13.4.6
 
 var builder = DistributedApplication.CreateBuilder(args);
 

--- a/samples/container-build/apphost.cs
+++ b/samples/container-build/apphost.cs
@@ -1,4 +1,4 @@
-#:sdk Aspire.AppHost.Sdk@13.4.0
+#:sdk Aspire.AppHost.Sdk@13.4.6
 
 using Microsoft.Extensions.Hosting;
 

--- a/samples/database-containers/DatabaseContainers.ApiService/DatabaseContainers.ApiService.csproj
+++ b/samples/database-containers/DatabaseContainers.ApiService/DatabaseContainers.ApiService.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Aspire.MySqlConnector" Version="13.4.6" />
     <PackageReference Include="Dapper" Version="2.1.79" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.16.11" />
   </ItemGroup>
 

--- a/samples/image-gallery/api/api.csproj
+++ b/samples/image-gallery/api/api.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Aspire.Azure.Storage.Queues" Version="13.4.0" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.14.11" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageReference Include="SkiaSharp" Version="3.119.1" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.1" />
   </ItemGroup>

--- a/samples/image-gallery/apphost.cs
+++ b/samples/image-gallery/apphost.cs
@@ -1,11 +1,11 @@
 #pragma warning disable ASPIRECSHARPAPPS001
 #pragma warning disable ASPIREAZURE002
 
-#:sdk Aspire.AppHost.Sdk@13.4.0
-#:package Aspire.Hosting.Azure.Storage@13.4.0
-#:package Aspire.Hosting.Azure.Sql@13.4.0
-#:package Aspire.Hosting.JavaScript@13.4.0
-#:package Aspire.Hosting.Azure.AppContainers@13.4.0
+#:sdk Aspire.AppHost.Sdk@13.4.6
+#:package Aspire.Hosting.Azure.Storage@13.4.6
+#:package Aspire.Hosting.Azure.Sql@13.4.6
+#:package Aspire.Hosting.JavaScript@13.4.6
+#:package Aspire.Hosting.Azure.AppContainers@13.4.6
 
 using Aspire.Hosting.Azure;
 using Azure.Provisioning.AppContainers;
@@ -108,4 +108,3 @@ var frontend = builder.AddViteApp("frontend", "./frontend")
 api.PublishWithContainerFiles(frontend, "wwwroot");
 
 builder.Build().Run();
-

--- a/samples/vite-csharp-postgres/api/Api.csproj
+++ b/samples/vite-csharp-postgres/api/Api.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.4.0" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.14.11" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #752

## Problem

In the `aspire-with-azure-functions` sample, the local Azure Functions host (`func host start`) was only ever served over **HTTP**. Simply adding `--useHttps` to the Functions launch profile is not enough — the .NET build of Azure Functions Core Tools cannot auto‑generate a certificate and fails to start:

```
Auto cert generation is currently not working on the .NET Core build.
```

`func host start --useHttps` requires an explicit **password‑protected** PFX via `--cert`/`--password`.

## Fix

- **`ImageGallery.Functions/Properties/launchSettings.json`** — add `--useHttps` so Aspire registers an `https` endpoint for the Functions resource.
- **`ImageGallery.AppHost/AppHost.cs`** —
  - Point `WithUrlForEndpoint` at the `https` endpoint.
  - In **run mode only**, export the trusted ASP.NET Core developer certificate via Aspire's `WithHttpsDeveloperCertificate(...)` and hand the resulting PFX to the Functions host with `WithHttpsCertificateConfiguration(...)` (`--cert <pfx> --password <generated>`). The export password is an ephemeral, per‑run secret parameter, so nothing is committed. The wiring is guarded by `IsRunMode` so it never affects publish/deploy.

Effective local launch becomes:
```
func host start --port 7221 --useHttps --cert <exported-dev-cert>.pfx --password <generated>
```

## Verification (local)

Tested locally with .NET 10, Aspire 13.4.3, Azure Functions Core Tools v4.12.0, Docker (Azurite):

**Before** — `curl http://localhost:7221/admin/host/status` → `200`; HTTPS TLS handshake fails (`SEC_E_INVALID_TOKEN`).

**After**
- `func` launches with `--useHttps --cert <pfx> --password <generated>` and listens on `:7221`.
- `curl https://localhost:7221/admin/host/status` (no `-k`) → **`200 OK`** with `{"state":"Running","version":"4.1048..."}` — i.e. served over HTTPS using the **trusted** dev cert.
- Plain `http://localhost:7221/...` now fails (port is HTTPS‑only).
- Frontend serves over HTTPS (`200`).
- End‑to‑end regression check: uploaded a 400×300 image to the `images` container → the `ThumbnailGenerator` blob trigger produced a 170×128 thumbnail in `thumbnails`. The pipeline is unaffected.

## Prerequisite

A trusted ASP.NET Core developer certificate (`dotnet dev-certs https --trust`) — already part of the Aspire prerequisites linked in the sample README.