### PR TITLE
Pin latest 2.x version of Microsoft.OpenApi

### DIFF
--- a/samples/aspire-shop/AspireShop.CatalogService/AspireShop.CatalogService.csproj
+++ b/samples/aspire-shop/AspireShop.CatalogService/AspireShop.CatalogService.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.11.0" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.16.16" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes restore that was broken due to transitive dep on Microsoft.OpenApi being to a now vulnerable version