### PR TITLE
Fix vulnerable .NET sample dependencies

### DIFF
--- a/samples/Metrics/MetricsApp.AppHost/MetricsApp.AppHost.csproj
+++ b/samples/Metrics/MetricsApp.AppHost/MetricsApp.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.0">
+<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/Metrics/ServiceDefaults/ServiceDefaults.csproj
+++ b/samples/Metrics/ServiceDefaults/ServiceDefaults.csproj
@@ -9,6 +9,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.11.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.8.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.8.0" />

--- a/samples/aspire-shop/AspireShop.AppHost/AspireShop.AppHost.csproj
+++ b/samples/aspire-shop/AspireShop.AppHost/AspireShop.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.0">
+<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/aspire-with-azure-functions/ImageGallery.AppHost/ImageGallery.AppHost.csproj
+++ b/samples/aspire-with-azure-functions/ImageGallery.AppHost/ImageGallery.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.0">
+<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/aspire-with-javascript/AspireJavaScript.AppHost/AspireJavaScript.AppHost.csproj
+++ b/samples/aspire-with-javascript/AspireJavaScript.AppHost/AspireJavaScript.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.0">
+<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/aspire-with-javascript/AspireJavaScript.MinimalApi/AspireJavaScript.MinimalApi.csproj
+++ b/samples/aspire-with-javascript/AspireJavaScript.MinimalApi/AspireJavaScript.MinimalApi.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.11.0" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.16.16" />
   </ItemGroup>
 

--- a/samples/aspire-with-node/AspireWithNode.AppHost/AspireWithNode.AppHost.csproj
+++ b/samples/aspire-with-node/AspireWithNode.AppHost/AspireWithNode.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.0">
+<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/aspire-with-python/apphost.cs
+++ b/samples/aspire-with-python/apphost.cs
@@ -1,7 +1,7 @@
-#:sdk Aspire.AppHost.Sdk@13.4.0
-#:package Aspire.Hosting.JavaScript@13.4.0
-#:package Aspire.Hosting.Python@13.4.0
-#:package Aspire.Hosting.Redis@13.4.0
+#:sdk Aspire.AppHost.Sdk@13.4.6
+#:package Aspire.Hosting.JavaScript@13.4.6
+#:package Aspire.Hosting.Python@13.4.6
+#:package Aspire.Hosting.Redis@13.4.6
 
 var builder = DistributedApplication.CreateBuilder(args);
 

--- a/samples/client-apps-integration/ClientAppsIntegration.AppHost/ClientAppsIntegration.AppHost.csproj
+++ b/samples/client-apps-integration/ClientAppsIntegration.AppHost/ClientAppsIntegration.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.0">
+<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/container-build/apphost.cs
+++ b/samples/container-build/apphost.cs
@@ -1,4 +1,4 @@
-#:sdk Aspire.AppHost.Sdk@13.4.0
+#:sdk Aspire.AppHost.Sdk@13.4.6
 
 using Microsoft.Extensions.Hosting;
 

--- a/samples/custom-resources/CustomResources.AppHost/CustomResources.AppHost.csproj
+++ b/samples/custom-resources/CustomResources.AppHost/CustomResources.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.0">
+<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/database-containers/DatabaseContainers.ApiService/DatabaseContainers.ApiService.csproj
+++ b/samples/database-containers/DatabaseContainers.ApiService/DatabaseContainers.ApiService.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Aspire.MySqlConnector" Version="13.4.6" />
     <PackageReference Include="Dapper" Version="2.1.79" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.11.0" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.16.16" />
   </ItemGroup>
 

--- a/samples/database-containers/DatabaseContainers.AppHost/DatabaseContainers.AppHost.csproj
+++ b/samples/database-containers/DatabaseContainers.AppHost/DatabaseContainers.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.0">
+<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/database-migrations/DatabaseMigrations.AppHost/DatabaseMigrations.AppHost.csproj
+++ b/samples/database-migrations/DatabaseMigrations.AppHost/DatabaseMigrations.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.0">
+<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/health-checks-ui/HealthChecksUI.AppHost/HealthChecksUI.AppHost.csproj
+++ b/samples/health-checks-ui/HealthChecksUI.AppHost/HealthChecksUI.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.0">
+<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/image-gallery/api/api.csproj
+++ b/samples/image-gallery/api/api.csproj
@@ -21,7 +21,8 @@
     <PackageReference Include="Aspire.Azure.Storage.Blobs" Version="13.4.0" />
     <PackageReference Include="Aspire.Azure.Storage.Queues" Version="13.4.0" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.14.11" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.11.0" />
     <PackageReference Include="SkiaSharp" Version="3.119.1" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.1" />
   </ItemGroup>

--- a/samples/image-gallery/apphost.cs
+++ b/samples/image-gallery/apphost.cs
@@ -1,11 +1,11 @@
 #pragma warning disable ASPIRECSHARPAPPS001
 #pragma warning disable ASPIREAZURE002
 
-#:sdk Aspire.AppHost.Sdk@13.4.0
-#:package Aspire.Hosting.Azure.Storage@13.4.0
-#:package Aspire.Hosting.Azure.Sql@13.4.0
-#:package Aspire.Hosting.JavaScript@13.4.0
-#:package Aspire.Hosting.Azure.AppContainers@13.4.0
+#:sdk Aspire.AppHost.Sdk@13.4.6
+#:package Aspire.Hosting.Azure.Storage@13.4.6
+#:package Aspire.Hosting.Azure.Sql@13.4.6
+#:package Aspire.Hosting.JavaScript@13.4.6
+#:package Aspire.Hosting.Azure.AppContainers@13.4.6
 
 using Aspire.Hosting.Azure;
 using Azure.Provisioning.AppContainers;
@@ -108,4 +108,3 @@ var frontend = builder.AddViteApp("frontend", "./frontend")
 api.PublishWithContainerFiles(frontend, "wwwroot");
 
 builder.Build().Run();
-

--- a/samples/orleans-voting/OrleansVoting.AppHost/OrleansVoting.AppHost.csproj
+++ b/samples/orleans-voting/OrleansVoting.AppHost/OrleansVoting.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.0">
+<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/vite-csharp-postgres/api/Api.csproj
+++ b/samples/vite-csharp-postgres/api/Api.csproj
@@ -15,7 +15,8 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.4.0" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.14.11" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/volume-mount/VolumeMount.AppHost/VolumeMount.AppHost.csproj
+++ b/samples/volume-mount/VolumeMount.AppHost/VolumeMount.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.0">
+<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
## Summary

- update all 15 C# AppHosts to Aspire AppHost SDK 13.4.6, resolving transitive MessagePack 2.5.192 to 2.5.302
- pin Microsoft.OpenApi 2.11.0 in five .NET samples affected by GHSA-v5pm-xwqc-g5wc
- update Microsoft.AspNetCore.OpenApi from 10.0.8 to 10.0.10 in the image-gallery and vite-csharp-postgres APIs

## Validation

- ran the repository build entry point successfully across all 25 samples
- audited all checked-in .NET projects and generated file-based AppHosts with no vulnerable packages reported